### PR TITLE
refactor: esm

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Current Test File",
+      "autoAttachChildProcesses": true,
+      "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+      "program": "node_modules/vitest/vitest.mjs",
+      "args": ["run", "${relativeFile}"],
+      "smartStep": true,
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/download-rehearsal-cli.sh
+++ b/download-rehearsal-cli.sh
@@ -4,10 +4,7 @@
 PROJECT_ROOT=$(pwd)
 
 # cleanup any existing tgz files
-rm -rf rehearsal-cli-*.tgz
-
-# remove any existing @rehearsal/cli deps
-pnpm remove @rehearsal/cli
+rm -rf rehearsal-*.tgz
 
 # download the zip from latest github master and unzip it
 wget https://github.com/rehearsal-js/rehearsal-js/archive/refs/heads/master.zip && unzip master.zip
@@ -15,29 +12,34 @@ wget https://github.com/rehearsal-js/rehearsal-js/archive/refs/heads/master.zip 
 # remove the zip
 rm -rf master.zip
 
-# go to the unzipped cli folder
-cd rehearsal-js-master/packages/cli
+# go to the unzipped folder
+cd rehearsal-js-master
 
-# install rehearsal-cli dependencies
+# install rehearsal-js dependencies
 pnpm install
 
-# build the cli
+# build the monorepo
 pnpm build
 
-# create the tarball in the root project folder and cd back to the project root
-pnpm pack --pack-destination $PROJECT_ROOT && cd $PROJECT_ROOT
+# cd into the monorepo packages dir
+cd packages
 
-# save the filename from pnpm pack into a sh variable
-REHEARSAL_CLI_TGZ=$(ls rehearsal-cli-*.tgz)
+# loop over the packages and pack them all to the root project folder
+for package in *; do
+  cd $package
+  echo $package
+  pnpm pack --pack-destination $PROJECT_ROOT
+  cd ..
+done
+
+# cd back to the project root
+cd $PROJECT_ROOT
 
 # cleanup the unzipped files
-rm -rf rehearsal-js-master
+rm -rf rehearsal-js-master node_modules && rm pnpm-lock.yaml
 
-# clean up
-rm -rf node_modules && rm pnpm-lock.yaml
-
-# add @rehearsal/cli to package.json from tarball eg. file:rehearsal-cli-0.0.0.tgz
-pnpm add -D file:$REHEARSAL_CLI_TGZ
-
-# install smoke-test depdendencies
-pnpm install
+# add @rehearsal/* to package.json from tarball eg. file:rehearsal-cli-0.0.0.tgz
+# loop over every tgz file and add it to package.json
+for tgz in *.tgz; do
+  pnpm add -D file:$tgz
+done

--- a/package.json
+++ b/package.json
@@ -3,21 +3,24 @@
   "version": "0.0.1",
   "description": "Rehearsal CLI Smoke Test",
   "private": true,
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "https://github.com/rehearsal-js/rehearsal-js.git"
   },
   "license": "BSD-2-Clause",
   "scripts": {
-    "fetch-rehearsal": "sh download-rehearsal-cli.sh",
+    "fetch-rehearsal": "sh download-rehearsal-cli.sh && node update-resolutions.js && pnpm install",
     "test": "vitest --run",
     "test:watch": "vitest --coverage --watch"
   },
   "devDependencies": {
     "execa": "^5.1.1",
+    "vite": "^4.1.4",
     "vitest": "^0.28.4"
   },
   "packageManager": "pnpm@7.12.1",
+  "resolutions": {},
   "engines": {
     "node": ">=14.16.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,10 +2,12 @@ lockfileVersion: 5.4
 
 specifiers:
   execa: ^5.1.1
+  vite: ^4.1.4
   vitest: ^0.28.4
 
 devDependencies:
   execa: 5.1.1
+  vite: 4.1.4
   vitest: 0.28.5
 
 packages:
@@ -218,8 +220,8 @@ packages:
     resolution: {integrity: sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==}
     dev: true
 
-  /@types/node/18.13.0:
-    resolution: {integrity: sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==}
+  /@types/node/18.14.6:
+    resolution: {integrity: sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==}
     dev: true
 
   /@vitest/expect/0.28.5:
@@ -492,7 +494,7 @@ packages:
       acorn: 8.8.2
       pathe: 1.1.0
       pkg-types: 1.0.2
-      ufo: 1.1.0
+      ufo: 1.1.1
     dev: true
 
   /ms/2.1.2:
@@ -586,8 +588,8 @@ packages:
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
 
-  /rollup/3.15.0:
-    resolution: {integrity: sha512-F9hrCAhnp5/zx/7HYmftvsNBkMfLfk/dXUh73hPSM2E3CRgap65orDNJbLetoiUFwSAk6iHPLvBrZ5iHYvzqsg==}
+  /rollup/3.18.0:
+    resolution: {integrity: sha512-J8C6VfEBjkvYPESMQYxKHxNOh4A5a3FlP+0BETGo34HEcE4eTlgCrO2+eWzlu2a/sHs2QUkZco+wscH7jhhgWg==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -698,11 +700,11 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /ufo/1.1.0:
-    resolution: {integrity: sha512-LQc2s/ZDMaCN3QLpa+uzHUOQ7SdV0qgv3VBXOolQGXTaaZpIur6PwUclF5nN2hNkiTRcUugXd1zFOW3FLJ135Q==}
+  /ufo/1.1.1:
+    resolution: {integrity: sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==}
     dev: true
 
-  /vite-node/0.28.5_@types+node@18.13.0:
+  /vite-node/0.28.5_@types+node@18.14.6:
     resolution: {integrity: sha512-LmXb9saMGlrMZbXTvOveJKwMTBTNUH66c8rJnQ0ZPNX+myPEol64+szRzXtV5ORb0Hb/91yq+/D3oERoyAt6LA==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
@@ -714,7 +716,7 @@ packages:
       picocolors: 1.0.0
       source-map: 0.6.1
       source-map-support: 0.5.21
-      vite: 4.1.2_@types+node@18.13.0
+      vite: 4.1.4_@types+node@18.14.6
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -725,8 +727,8 @@ packages:
       - terser
     dev: true
 
-  /vite/4.1.2_@types+node@18.13.0:
-    resolution: {integrity: sha512-MWDb9Rfy3DI8omDQySbMK93nQqStwbsQWejXRY2EBzEWKmLAXWb1mkI9Yw2IJrc+oCvPCI1Os5xSSIBYY6DEAw==}
+  /vite/4.1.4:
+    resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -750,11 +752,44 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 18.13.0
       esbuild: 0.16.17
       postcss: 8.4.21
       resolve: 1.22.1
-      rollup: 3.15.0
+      rollup: 3.18.0
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /vite/4.1.4_@types+node@18.14.6:
+    resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.14.6
+      esbuild: 0.16.17
+      postcss: 8.4.21
+      resolve: 1.22.1
+      rollup: 3.18.0
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
@@ -783,7 +818,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.4
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.13.0
+      '@types/node': 18.14.6
       '@vitest/expect': 0.28.5
       '@vitest/runner': 0.28.5
       '@vitest/spy': 0.28.5
@@ -802,8 +837,8 @@ packages:
       tinybench: 2.3.1
       tinypool: 0.3.1
       tinyspy: 1.1.1
-      vite: 4.1.2_@types+node@18.13.0
-      vite-node: 0.28.5_@types+node@18.13.0
+      vite: 4.1.4_@types+node@18.14.6
+      vite-node: 0.28.5_@types+node@18.14.6
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -8,41 +8,42 @@
  * TypeScript should NOT be configured by default in this package.
  * This package should mimic the user experience as closely as possible.
  */
-
-import { describe, expect, test } from 'vitest';
-import { commandSync } from 'execa';
+import Module from "node:module";
+import { describe, expect, test } from "vitest";
+import { commandSync } from "execa";
 // This binary is coming from the "download-rehearsal-cli" script
 // we want to test the CLI binary that is downloaded from the master branch
 // of https://github.com/rehearsal-js/rehearsal-js
 // and NOT the @rehearsal/cli version published to npm
-const CLI_BIN = require.resolve('@rehearsal/cli/bin/rehearsal.js');
+const require = Module.createRequire(import.meta.url);
+const CLI_BIN = require.resolve("@rehearsal/cli/bin/rehearsal.js");
 
 const run = (args, options) => {
-  return commandSync(`node ${CLI_BIN} ${args.join(' ')}`, options);
+  return commandSync(`node ${CLI_BIN} ${args.join(" ")}`, options);
 };
 
-describe('smoke-test @rehearsal/cli', () => {
-  test('without command only --help', () => {
-    const results = run(['--help']);
+describe("smoke-test @rehearsal/cli", () => {
+  test("without command only --help", () => {
+    const results = run(["--help"]);
     expect(results.exitCode).toBe(0);
-    expect(results.stdout).toContain('Usage: rehearsal [options] [command]');
-    expect(results.stdout).toContain('migrate [options]');
-    expect(results.stdout).toContain('upgrade [options] [basePath]');
+    expect(results.stdout).toContain("Usage: rehearsal [options] [command]");
+    expect(results.stdout).toContain("migrate [options]");
+    expect(results.stdout).toContain("upgrade [options] [basePath]");
   });
 });
 
-describe('smoke-test @rehearsal/cli migrate', () => {
-  test('migrate command --help', () => {
-    const results = run(['migrate', '--help']);
+describe("smoke-test @rehearsal/cli migrate", () => {
+  test("migrate command --help", () => {
+    const results = run(["migrate", "--help"]);
     expect(results.exitCode).toBe(0);
-    expect(results.stdout).toContain('migrate [options]');
+    expect(results.stdout).toContain("migrate [options]");
   });
 });
 
-describe('smoke-test @rehearsal/cli upgrade', () => {
-  test('upgrade command --help', () => {
-    const results = run(['upgrade', '--help']);
+describe("smoke-test @rehearsal/cli upgrade", () => {
+  test("upgrade command --help", () => {
+    const results = run(["upgrade", "--help"]);
     expect(results.exitCode).toBe(0);
-    expect(results.stdout).toContain('upgrade [options] [basePath]');
+    expect(results.stdout).toContain("upgrade [options] [basePath]");
   });
 });

--- a/update-resolutions.js
+++ b/update-resolutions.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+// save the project root path
+const PROJECT_ROOT = process.cwd();
+const packageJson = JSON.parse(
+  readFileSync(join(PROJECT_ROOT, "package.json"), "utf8")
+);
+
+// read the package.json devDependencies and save everything starting with @rehearsal/* to the resolutions object
+Object.keys(packageJson.devDependencies).forEach((key) => {
+  if (key.startsWith("@rehearsal/")) {
+    packageJson.resolutions = packageJson.resolutions || {};
+    packageJson.resolutions[key] = packageJson.devDependencies[key];
+  }
+});
+
+// write the package.json file
+writeFileSync(
+  join(PROJECT_ROOT, "package.json"),
+  JSON.stringify(packageJson, null, 2)
+);


### PR DESCRIPTION
This PR refactors the smoke-test for consuming the new ESM rehearsal cli. It also expands the functionality by forcing the resolution of the local tar for each package in rehearsal. 