### PR TITLE
chore: add the ability to pass the branch name

### DIFF
--- a/.github/workflows/run-smoke-test.yml
+++ b/.github/workflows/run-smoke-test.yml
@@ -2,6 +2,11 @@ name: CLI-Smoke-Test
 
 on:
   workflow_dispatch:
+    inputs:
+      branch_name:
+        type: string
+        default: "master"
+        description: The branch we will checkout
     branches:
       - master
   push:
@@ -20,5 +25,6 @@ jobs:
       - uses: pnpm/action-setup@v2.2.4
         with:
           version: 7
-      - run: pnpm fetch-rehearsal
+      - run: sh download-rehearsal-cli.sh ${{ github.event.inputs.branch_name }}
+      - run: pnpm run update-resolutions
       - run: pnpm test

--- a/download-rehearsal-cli.sh
+++ b/download-rehearsal-cli.sh
@@ -3,17 +3,23 @@
 # save the project root path
 PROJECT_ROOT=$(pwd)
 
+BRANCH=$1
+ZIP_NAME=$(echo $BRANCH | sed "s/.*\///")
+UNZIPPED_NAME=$(echo $BRANCH | sed -e 's/\//-/g')
+
 # cleanup any existing tgz files
 rm -rf rehearsal-*.tgz
 
-# download the zip from latest github master and unzip it
-wget https://github.com/rehearsal-js/rehearsal-js/archive/refs/heads/master.zip && unzip master.zip
+# download the zip from the branch nd unzip it
+wget https://github.com/rehearsal-js/rehearsal-js/archive/$BRANCH.zip
+
+unzip ${ZIP_NAME}.zip
 
 # remove the zip
-rm -rf master.zip
+rm -rf ${ZIP_NAME}.zip
 
 # go to the unzipped folder
-cd rehearsal-js-master
+cd rehearsal-js-${UNZIPPED_NAME}
 
 # install rehearsal-js dependencies
 pnpm install --no-frozen-lockfile
@@ -36,7 +42,7 @@ done
 cd $PROJECT_ROOT
 
 # cleanup the unzipped files
-rm -rf rehearsal-js-master node_modules && rm pnpm-lock.yaml
+rm -rf rehearsal-js-${UNZIPPED_NAME} node_modules && rm pnpm-lock.yaml
 
 # add @rehearsal/* to package.json from tarball eg. file:rehearsal-cli-0.0.0.tgz
 # loop over every tgz file and add it to package.json

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "BSD-2-Clause",
   "scripts": {
-    "fetch-rehearsal": "sh download-rehearsal-cli.sh && node update-resolutions.js && pnpm install --no-frozen-lockfile",
+    "update-resolutions": "node update-resolutions.js && pnpm install --no-frozen-lockfile",
     "test": "vitest --run",
     "test:watch": "vitest --coverage --watch"
   },


### PR DESCRIPTION
This PR changes how we run the smoke test during a workflow. Prior to this change we would only pull master of the rehearsal-js to test against a PR. This effectively meant that we wouldn't test the changes until after the PR has been merged leaving us in a broken state on the master branch. This made sure that we did not release a breaking binary, but ideally we would shift left and do this test before the PR is merged.

This changes the workflow to have a branch_name input (defaults to master) which will be sent in within rehearsal it self. In doing so we can get the tarball of the PR and test those changes against this repo.

This needs to land before https://github.com/rehearsal-js/rehearsal-js/pull/808