### PR TITLE
chore: fix workflow for prs

### DIFF
--- a/.github/workflows/run-smoke-test.yml
+++ b/.github/workflows/run-smoke-test.yml
@@ -12,6 +12,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   run-smoke-test:

--- a/download-rehearsal-cli.sh
+++ b/download-rehearsal-cli.sh
@@ -3,7 +3,11 @@
 # save the project root path
 PROJECT_ROOT=$(pwd)
 
-BRANCH=$1
+if [ ! $@ ];
+  then BRANCH='master'
+  else BRANCH=$1
+fi
+
 ZIP_NAME=$(echo $BRANCH | sed "s/.*\///")
 UNZIPPED_NAME=$(echo $BRANCH | sed -e 's/\//-/g')
 


### PR DESCRIPTION
Prior to this change PRs would not find the correct branch to test for pushes to master and lead to the master branch being broken. This does 2 things:

- defaults the bash script to "master" if `download-rehearsal-cli.sh` is called without arguments
- adds workflow config to run the master branch of rehearsal against PRs 