### PR TITLE
feat: add validation test for graph, migrate

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "execa": "^5.1.1",
+    "fixturify-project": "^5.2.0",
     "vite": "^4.1.4",
     "vitest": "^0.28.4"
   },

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -9,6 +9,7 @@
 import Module from 'node:module';
 import { describe, expect, test } from 'vitest';
 import { commandSync } from 'execa';
+import { runCommandFactory } from './test-helpers';
 // This binary is coming from the "download-rehearsal-cli" script
 // we want to test the CLI binary that is downloaded from the master branch
 // of https://github.com/rehearsal-js/rehearsal-js
@@ -16,9 +17,7 @@ import { commandSync } from 'execa';
 const require = Module.createRequire(import.meta.url);
 const CLI_BIN = require.resolve('@rehearsal/cli/bin/rehearsal.js');
 
-const run = (args, options) => {
-  return commandSync(`node ${CLI_BIN} ${args.join(' ')}`, options);
-};
+const run = runCommandFactory(CLI_BIN);
 
 describe('smoke-test @rehearsal/cli', () => {
   test('without command only --help', () => {

--- a/test/graph.test.js
+++ b/test/graph.test.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+import { describe, expect, test, beforeEach } from 'vitest';
+import { Project } from 'fixturify-project';
+import { runCommandFactory, setupProject, resolveCLIBin } from './test-helpers';
+
+describe('validation-test @rehearsal/cli graph', () => {
+  let run;
+
+  beforeEach(async () => {
+    let project = new Project('simple', '1.0.0', {
+      files: {
+        'index.js': `
+          import './lib/hotdog';
+          import './lib/burger';
+        `,
+        lib: {
+          'hotdog.js': `import './sandwich';`,
+          'burger.js': `import './sandwich';`,
+          'sandwich.js': `import 'chalk';`
+        }
+      }
+    });
+    project.pkg.exports = './index.js';
+    project.pkg.volta = {
+      node: '16.19.0'
+    };
+    project.addDependency('chalk', '5.2.0');
+
+    // Setup project with dependencies to use rehearsal e.g. typescript, eslint, prettier
+    await setupProject(project);
+
+    const bin = resolveCLIBin(project);
+
+    // Set up command for tests
+    run = runCommandFactory(bin, { cwd: project.baseDir });
+  });
+
+  test('graph --help', () => {
+    const results = run(['graph', '--help']);
+    // Dumping the output for debuggability
+    console.log(results.stdout);
+    expect(results.exitCode).toBe(0);
+    expect(results.stdout).toContain('graph [options] [basePath]');
+  });
+
+  test('graph', () => {
+    const results = run(['graph']);
+    // Dumping the output for debuggability
+    console.log(results.stdout);
+    expect(results.exitCode).toBe(0);
+
+    expect(results.stdout).toContain(`[STARTED] Analyzing project dependency graph`);
+
+    const output = results.stdout
+      .split('\n')
+      .filter((line) => line.startsWith('[DATA]'))
+      .map((line) => line.slice('[DATA] '.length));
+
+    // Assert the printed graph order of the files
+    expect(output).toStrictEqual([
+      "Graph order for '.':",
+      '',
+      'lib/sandwich.js',
+      'lib/burger.js',
+      'lib/hotdog.js',
+      'index.js'
+    ]);
+
+    expect(results.stdout).toContain('[SUCCESS] Analyzing project dependency graph');
+  });
+
+  test.todo('graph basePath', () => {});
+  test.todo('graph --output', () => {});
+});

--- a/test/graph.test.js
+++ b/test/graph.test.js
@@ -38,18 +38,14 @@ describe('validation-test @rehearsal/cli graph', () => {
 
   test('graph --help', () => {
     const results = run(['graph', '--help']);
-    // Dumping the output for debuggability
-    console.log(results.stdout);
     expect(results.exitCode).toBe(0);
     expect(results.stdout).toContain('graph [options] [basePath]');
   });
 
   test('graph', () => {
     const results = run(['graph']);
-    // Dumping the output for debuggability
-    console.log(results.stdout);
-    expect(results.exitCode).toBe(0);
 
+    expect(results.exitCode).toBe(0);
     expect(results.stdout).toContain(`[STARTED] Analyzing project dependency graph`);
 
     const output = results.stdout

--- a/test/graph.test.js
+++ b/test/graph.test.js
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
 
-import { describe, expect, test, beforeEach } from 'vitest';
+import { describe, expect, test, afterEach, beforeEach } from 'vitest';
 import { Project } from 'fixturify-project';
 import { runCommandFactory, setupProject, resolveCLIBin } from './test-helpers';
 
 describe('validation-test @rehearsal/cli graph', () => {
   let run;
+  let project;
 
   beforeEach(async () => {
-    let project = new Project('simple', '1.0.0', {
+    project = new Project('simple', '1.0.0', {
       files: {
         'index.js': `
           import './lib/hotdog';
@@ -34,6 +35,10 @@ describe('validation-test @rehearsal/cli graph', () => {
 
     // Set up command for tests
     run = runCommandFactory(bin, { cwd: project.baseDir });
+  });
+
+  afterEach(async () => {
+    project.dispose();
   });
 
   test('graph --help', () => {

--- a/test/migrate.test.js
+++ b/test/migrate.test.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+import { describe, expect, test, beforeEach } from 'vitest';
+import { Project } from 'fixturify-project';
+import { runCommandFactory, setupProject, resolveCLIBin } from './test-helpers';
+
+describe('validation-test @rehearsal/cli migrate', () => {
+  let run;
+
+  beforeEach(async () => {
+    let project = new Project('simple', '1.0.0', {
+      files: {
+        'index.js': `
+          import './lib/hotdog';
+          import './lib/burger';
+        `,
+        lib: {
+          'hotdog.js': `import './sandwich';`,
+          'burger.js': `import './sandwich';`,
+          'sandwich.js': `import 'chalk';`
+        }
+      }
+    });
+    project.addDependency('chalk', '5.2.0');
+
+    // Setup project with dependencies to use rehearsal e.g. typescript, eslint, prettier
+    await setupProject(project);
+    const bin = resolveCLIBin(project);
+
+    // Set up command for tests
+    run = runCommandFactory(bin, { cwd: project.baseDir });
+  });
+
+  test('migrate --ci', async () => {
+    // TODO refactor to move and fix when avaiable
+    const results = run(['migrate', '--ci']);
+
+    // Dumping the output for debuggability
+    console.log(results.stdout);
+    expect(results.stdout).toContain('[STARTED] Convert JS files to TS');
+    expect(results.stdout).toContain('[DATA] git mv /lib/sandwich.js to /lib/sandwich.ts');
+    expect(results.stdout).toContain('[DATA] git mv /lib/burger.js to /lib/burger.ts');
+    expect(results.stdout).toContain('[DATA] git mv /lib/hotdog.js to /lib/hotdog.ts');
+    expect(results.stdout).toContain('[DATA] git mv /index.js to /index.ts');
+    expect(results.stdout).toContain('[DATA] processing file: /lib/sandwich.ts');
+    expect(results.stdout).toContain('[DATA] processing file: /lib/burger.ts');
+    expect(results.stdout).toContain('[DATA] processing file: /lib/hotdog.ts');
+    expect(results.stdout).toContain('[DATA] processing file: /index.ts');
+    expect(results.stdout).toContain('[SUCCESS] Migration Complete');
+  });
+});

--- a/test/migrate.test.js
+++ b/test/migrate.test.js
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
 
-import { describe, expect, test, beforeEach } from 'vitest';
+import { describe, expect, test, afterEach, beforeEach } from 'vitest';
 import { Project } from 'fixturify-project';
 import { runCommandFactory, setupProject, resolveCLIBin } from './test-helpers';
 
 describe('validation-test @rehearsal/cli migrate', () => {
   let run;
+  let project;
 
   beforeEach(async () => {
-    let project = new Project('simple', '1.0.0', {
+    project = new Project('simple', '1.0.0', {
       files: {
         'index.js': `
           import './lib/hotdog';
@@ -29,6 +30,10 @@ describe('validation-test @rehearsal/cli migrate', () => {
 
     // Set up command for tests
     run = runCommandFactory(bin, { cwd: project.baseDir });
+  });
+
+  afterEach(async () => {
+    project.dispose();
   });
 
   test('migrate --ci', async () => {

--- a/test/migrate.test.js
+++ b/test/migrate.test.js
@@ -36,7 +36,6 @@ describe('validation-test @rehearsal/cli migrate', () => {
     const results = run(['migrate', '--ci']);
 
     // Dumping the output for debuggability
-    console.log(results.stdout);
     expect(results.stdout).toContain('[STARTED] Convert JS files to TS');
     expect(results.stdout).toContain('[DATA] git mv /lib/sandwich.js to /lib/sandwich.ts');
     expect(results.stdout).toContain('[DATA] git mv /lib/burger.js to /lib/burger.ts');

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -1,0 +1,116 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import Module from 'node:module';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { commandSync } from 'execa';
+
+const PROJECT_ROOT = new URL('../', import.meta.url);
+
+export function getRehearsalPackagePaths() {
+  // read the package.json devDependencies
+  const ROOT_PACKAGE_JSON = new URL('./package.json', PROJECT_ROOT);
+  const rootPackageJson = JSON.parse(readFileSync(ROOT_PACKAGE_JSON, 'utf8'));
+
+  // Iterate over devDependencies from the root projet's package.json
+  // and filter for @rehearsal/ packages
+  // Creates a array of tuples like:
+  // [@rehearsal/cli, file:rehearsal-cli-2.X.X-beta.tgz, file:///path/to/project/root/rehearsal-cli-2.X.X-beta.tgz]
+
+  const packagePaths = Object.entries(rootPackageJson.devDependencies)
+    .filter(([packageName]) => packageName.startsWith('@rehearsal/'))
+    .map(([packageName, packageResolutionUrl]) => {
+      const pathToPackage = new URL(packageResolutionUrl, PROJECT_ROOT);
+      return [packageName, packageResolutionUrl, pathToPackage];
+    });
+
+  if (packagePaths.length < 1) {
+    throw new Error(
+      'Unable to find rehearsal dependencies in root package.json. Did you run `sh download-rehearsal-cli.sh` ?'
+    );
+  }
+
+  return packagePaths;
+}
+
+/**
+ * Add the necessary devDependencies for a project fixture to run rehearasl.
+ * @param {Project} project
+ * @returns
+ */
+export async function setupProject(project) {
+  // Typescript
+  project.addDevDependency('typescript', '5.0.4');
+
+  // Eslint
+  project.addDevDependency('eslint', '8.38.0');
+  project.addDevDependency('@typescript-eslint/eslint-plugin', '5.59.0');
+  project.addDevDependency('@typescript-eslint/parser', '5.59.0');
+
+  // Prettier
+  project.addDevDependency('prettier', '2.8.7');
+  project.addDevDependency('eslint-config-prettier', '8.8.0');
+  project.addDevDependency('eslint-plugin-prettier', '4.2.1');
+
+  let packagePaths = getRehearsalPackagePaths();
+
+  if (!project.pkg.devDependencies) {
+    project.pkg.devDependencies = {};
+  }
+
+  await project.write();
+
+  // Read package.json
+  const packageJson = JSON.parse(readFileSync(join(project.baseDir, 'package.json'), 'utf8'));
+
+  packageJson['packageManager'] = 'pnpm@7.12.1';
+  packageJson['resolutions'] = {};
+
+  // Add all the rehearsal dependencies
+  for (const [packageName, localPath] of packagePaths) {
+    // Can't use addDev because that uses NPM and it complains about an invalid dependency
+    packageJson['devDependencies'][packageName] = localPath;
+    packageJson['resolutions'][packageName] = localPath;
+  }
+
+  // write the package.json file
+  writeFileSync(join(project.baseDir, 'package.json'), JSON.stringify(packageJson, null, 2));
+
+  // Copy binaries to root of project fixture
+  for (const [, , tarballPath] of packagePaths) {
+    commandSync(`cp ${fileURLToPath(tarballPath)} ./`, { cwd: project.baseDir });
+  }
+
+  let results;
+
+  // Install dependencies
+  results = commandSync('pnpm install', { cwd: project.baseDir });
+
+  if (results.exitCode !== 0) {
+    throw new Error(`Install failed; unable to setup project fixture.\n${results.stderr}`);
+  }
+
+  return project;
+}
+
+/**
+ *
+ * @param {Project} project fixturify-project
+ * @returns string path to rehearsal/cli bin within the project fixture.
+ */
+export function resolveCLIBin(project) {
+  // Resolve the rehearsal CLI bin relative the installed instance for project fixture
+  const require = Module.createRequire(join(project.baseDir, 'package.json'));
+  const bin = require.resolve('@rehearsal/cli/bin/rehearsal.js');
+  console.log('Fixture Root: ', project.baseDir);
+  console.log('Path to CLI in Fixture: ', bin);
+  return bin;
+}
+
+export function runCommandFactory(rehearsalCLIBin, factoryOptions) {
+  return (args, options) => {
+    return commandSync(`node ${rehearsalCLIBin} ${args.join(' ')}`, {
+      ...factoryOptions,
+      ...options
+    });
+  };
+}

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -110,8 +110,6 @@ export function resolveCLIBin(project) {
   // Resolve the rehearsal CLI bin relative the installed instance for project fixture
   const require = Module.createRequire(join(project.baseDir, 'package.json'));
   const bin = require.resolve('@rehearsal/cli/bin/rehearsal.js');
-  console.log('Fixture Root: ', project.baseDir);
-  console.log('Path to CLI in Fixture: ', bin);
   return bin;
 }
 

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -6,10 +6,21 @@ import { commandSync } from 'execa';
 
 const PROJECT_ROOT = new URL('../', import.meta.url);
 
+/**
+ * @param {string} baseDir string path to a directory.
+ * @returns pojo of package.json
+ */
+function readPackageJson(baseDir) {
+  const pathToPackageJson = join(baseDir, './package.json');
+  return JSON.parse(readFileSync(pathToPackageJson, 'utf8'));
+}
+
+function writePackageJson(baseDir, packageJson) {
+  writeFileSync(join(baseDir, 'package.json'), JSON.stringify(packageJson, null, 2));
+}
+
 export function getRehearsalPackagePaths() {
-  // read the package.json devDependencies
-  const ROOT_PACKAGE_JSON = new URL('./package.json', PROJECT_ROOT);
-  const rootPackageJson = JSON.parse(readFileSync(ROOT_PACKAGE_JSON, 'utf8'));
+  const rootPackageJson = readPackageJson(fileURLToPath(PROJECT_ROOT));
 
   // Iterate over devDependencies from the root projet's package.json
   // and filter for @rehearsal/ packages
@@ -59,8 +70,7 @@ export async function setupProject(project) {
 
   await project.write();
 
-  // Read package.json
-  const packageJson = JSON.parse(readFileSync(join(project.baseDir, 'package.json'), 'utf8'));
+  const packageJson = readPackageJson(project.baseDir);
 
   packageJson['packageManager'] = 'pnpm@7.12.1';
   packageJson['resolutions'] = {};
@@ -72,8 +82,7 @@ export async function setupProject(project) {
     packageJson['resolutions'][packageName] = localPath;
   }
 
-  // write the package.json file
-  writeFileSync(join(project.baseDir, 'package.json'), JSON.stringify(packageJson, null, 2));
+  writePackageJson(project.baseDir, packageJson);
 
   // Copy binaries to root of project fixture
   for (const [, , tarballPath] of packagePaths) {

--- a/update-resolutions.js
+++ b/update-resolutions.js
@@ -1,22 +1,21 @@
 #!/usr/bin/env node
-import { readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import {
+  findRehearsalPackages,
+  readPackageJson,
+  updatePackageJson,
+  writePackageJson
+} from './utils.js';
 // save the project root path
 const PROJECT_ROOT = process.cwd();
-const packageJson = JSON.parse(
-  readFileSync(join(PROJECT_ROOT, "package.json"), "utf8")
-);
 
-// read the package.json devDependencies and save everything starting with @rehearsal/* to the resolutions object
-Object.keys(packageJson.devDependencies).forEach((key) => {
-  if (key.startsWith("@rehearsal/")) {
-    packageJson.resolutions = packageJson.resolutions || {};
-    packageJson.resolutions[key] = packageJson.devDependencies[key];
-  }
-});
+let packageJson = readPackageJson(PROJECT_ROOT);
+
+// read the package.json devDependencies and save everything
+// starting with @rehearsal/* to the resolutions object
+const packagePaths = findRehearsalPackages(packageJson);
+
+// Update the packageJson pojo with the found rehearsal packages.
+packageJson = updatePackageJson(packageJson, packagePaths);
 
 // write the package.json file
-writeFileSync(
-  join(PROJECT_ROOT, "package.json"),
-  JSON.stringify(packageJson, null, 2)
-);
+writePackageJson(PROJECT_ROOT, packageJson);

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,71 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { URL, fileURLToPath } from 'node:url';
+
+import { join, resolve } from 'node:path';
+
+const PROJECT_ROOT = new URL('./', import.meta.url);
+const PROJECT_ROOT_DIR = fileURLToPath(PROJECT_ROOT);
+
+/**
+ * @param {string} baseDir string path to a directory.
+ * @returns pojo of package.json
+ */
+export function readPackageJson(baseDir) {
+  const pathToPackageJson = join(baseDir, './package.json');
+  return JSON.parse(readFileSync(pathToPackageJson, 'utf8'));
+}
+
+export function writePackageJson(baseDir, packageJson) {
+  writeFileSync(join(baseDir, 'package.json'), JSON.stringify(packageJson, null, 2));
+}
+
+/**
+ *
+ * @param {string} baseDir directory to lookup package.json.
+ * @returns
+ */
+export function findRehearsalPackages(packageJson) {
+  // Iterate over devDependencies from the root projet's package.json
+  // and filter for @rehearsal/ packages
+  // Creates a array of tuples like:
+  // [@rehearsal/cli, file:rehearsal-cli-2.X.X-beta.tgz]
+  if (!packageJson.devDependencies) {
+    throw new Error('package.json does have a devDependencies entry');
+  }
+
+  const packagePaths = Object.entries(packageJson.devDependencies).filter(([packageName]) =>
+    packageName.startsWith('@rehearsal/')
+  );
+
+  if (packagePaths.length < 1) {
+    throw new Error(
+      'Unable to find rehearsal dependencies in package.json. Did you run `sh download-rehearsal-cli.sh` ?'
+    );
+  }
+
+  return packagePaths;
+}
+
+/**
+ *
+ * @param {Object} packageJson a POJO representing a package.json file.
+ * @param {string[]} packagePaths an array of tuples [packageName, packagePath]
+ * @returns
+ */
+export function updatePackageJson(packageJson, packagePaths) {
+  if (!packageJson['devDependencies']) {
+    packageJson['devDependencies'] = {};
+  }
+
+  if (!packageJson['resolutions']) {
+    packageJson['resolutions'] = {};
+  }
+
+  for (const [packageName, packagePath] of packagePaths) {
+    console.log(packageName, packagePath);
+    packageJson['devDependencies'][packageName] = packagePath;
+    packageJson['resolutions'][packageName] = packagePath;
+  }
+
+  return packageJson;
+}

--- a/utils.js
+++ b/utils.js
@@ -62,7 +62,6 @@ export function updatePackageJson(packageJson, packagePaths) {
   }
 
   for (const [packageName, packagePath] of packagePaths) {
-    console.log(packageName, packagePath);
     packageJson['devDependencies'][packageName] = packagePath;
     packageJson['resolutions'][packageName] = packagePath;
   }


### PR DESCRIPTION
### Summary
Adding a validation test for running against a simple JS project fixture:
* `rehearsal graph` 
* `rehearsal migrate` 

These tests will exercise the commands to validate packaging, and the minimum project requirements  to run rehersal.

### Details
- Replicated tarball devDep and resolution work in project-fixture
  - Copy tarballs to project-fixture root directories
  - Add `devDependencies` and `resolutions` to the project fixture pointing to the local tarball.
  - Use `pnpm install` 
    - **npm**  could not be used due to runtime failures when trying to run graph or migrate.
    -  **yarn** could not be used because it wouldn't respect the local tarball resolution.

### Considerations
- The `migrate` command can be dropped once `fix` is made available.
- Asserting output and order may not be appropriate as the CLI output may change. 