### PR TITLE
feat: add graph command to cli test

### DIFF
--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -6,33 +6,43 @@
  * TypeScript should NOT be configured by default in this package.
  * This package should mimic the user experience as closely as possible.
  */
-import Module from "node:module";
-import { describe, expect, test } from "vitest";
-import { commandSync } from "execa";
+import Module from 'node:module';
+import { describe, expect, test } from 'vitest';
+import { commandSync } from 'execa';
 // This binary is coming from the "download-rehearsal-cli" script
 // we want to test the CLI binary that is downloaded from the master branch
 // of https://github.com/rehearsal-js/rehearsal-js
 // and NOT the @rehearsal/cli version published to npm
 const require = Module.createRequire(import.meta.url);
-const CLI_BIN = require.resolve("@rehearsal/cli/bin/rehearsal.js");
+const CLI_BIN = require.resolve('@rehearsal/cli/bin/rehearsal.js');
 
 const run = (args, options) => {
-  return commandSync(`node ${CLI_BIN} ${args.join(" ")}`, options);
+  return commandSync(`node ${CLI_BIN} ${args.join(' ')}`, options);
 };
 
-describe("smoke-test @rehearsal/cli", () => {
-  test("without command only --help", () => {
-    const results = run(["--help"]);
+describe('smoke-test @rehearsal/cli', () => {
+  test('without command only --help', () => {
+    const results = run(['--help']);
     expect(results.exitCode).toBe(0);
-    expect(results.stdout).toContain("Usage: rehearsal [options] [command]");
-    expect(results.stdout).toContain("migrate [options]");
+    expect(results.stdout).toContain('Usage: rehearsal [options] [command]');
+    expect(results.stdout).toContain('migrate [options]');
+    expect(results.stdout).toContain('graph [options] [basePath]');
   });
 });
 
-describe("smoke-test @rehearsal/cli migrate", () => {
-  test("migrate command --help", () => {
-    const results = run(["migrate", "--help"]);
+describe('smoke-test @rehearsal/cli migrate', () => {
+  test('migrate command --help', () => {
+    const results = run(['migrate', '--help']);
     expect(results.exitCode).toBe(0);
-    expect(results.stdout).toContain("migrate [options]");
+    expect(results.stdout).toContain('migrate [options]');
+  });
+});
+
+describe('smoke-test @rehearsal/cli graph', () => {
+  test('graph command --help', () => {
+    const results = run(['graph', '--help']);
+    expect(results.exitCode).toBe(0);
+    console.log(results.stdout);
+    expect(results.stdout).toContain('graph [options] [basePath]');
   });
 });


### PR DESCRIPTION
This simply extends the existing `cli.test.js` to have a graph smoke test.

Prettier ran on file and formatted quotes