### PR TITLE
fix: remove she-bang from top of test file

### DIFF
--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /**
  * The purpose of this package is to provide a simple smoke test for @rehearsal/cli commands.
  * It is not intended to be used in production, nor should it be published to npm.


### PR DESCRIPTION
The she-bang at the top of the test file `test/cli.test.js` was causing a syntax error causing smoke test to fail to run.

Originally reported here:
https://github.com/rehearsal-js/smoke-test/actions/runs/4756750329/jobs/8452714318

Reproduced from HEAD of this repo.


```
 RERUN  test/cli.test.js x1

 ❯ test/cli.test.js (0)

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  test/cli.test.js [ test/cli.test.js ]
SyntaxError: Invalid or unexpected token
 ❯ new Script node:vm:100:7
 ❯ createScript node:vm:265:10
 ❯ Object.runInThisContext node:vm:313:10

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯

 Test Files  1 failed (1)
      Tests  no tests
   Start at  15:42:36
   Duration  0ms
```