### PR TITLE
feat(validation): adds tests for graph and migrate for ember LTS `3.28`  and `4.4` using super-rentals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,5 @@ rehearsal-js-master/
 *.tar.gz
 
 action-test.sh
+
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -110,4 +110,5 @@ rehearsal-js-master/
 
 action-test.sh
 
+# tmp dir for checked out super-rentals versions.
 tmp/

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:watch": "vitest --coverage --watch"
   },
   "devDependencies": {
+    "debug": "^4.3.4",
     "execa": "^5.1.1",
     "fixturify-project": "^5.2.0",
     "json5": "^2.2.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "execa": "^5.1.1",
     "fixturify-project": "^5.2.0",
+    "json5": "^2.2.3",
     "vite": "^4.1.4",
     "vitest": "^0.28.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,9 @@
 lockfileVersion: '6.0'
 
 devDependencies:
+  debug:
+    specifier: ^4.3.4
+    version: 4.3.4
   execa:
     specifier: ^5.1.1
     version: 5.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,27 +1,25 @@
-lockfileVersion: 5.4
-
-specifiers:
-  execa: ^5.1.1
-  vite: ^4.1.4
-  vitest: ^0.28.4
+lockfileVersion: '6.0'
 
 devDependencies:
-  execa: 5.1.1
-  vite: 4.1.4
-  vitest: 0.28.5
+  execa:
+    specifier: ^5.1.1
+    version: 5.1.1
+  fixturify-project:
+    specifier: ^5.2.0
+    version: 5.2.0
+  json5:
+    specifier: ^2.2.3
+    version: 2.2.3
+  vite:
+    specifier: ^4.1.4
+    version: 4.1.4(@types/node@18.14.6)
+  vitest:
+    specifier: ^0.28.4
+    version: 0.28.5
 
 packages:
 
-  /@esbuild/android-arm/0.16.17:
-    resolution: {integrity: sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-arm64/0.16.17:
+  /@esbuild/android-arm64@0.16.17:
     resolution: {integrity: sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==}
     engines: {node: '>=12'}
     cpu: [arm64]
@@ -30,7 +28,16 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-x64/0.16.17:
+  /@esbuild/android-arm@0.16.17:
+    resolution: {integrity: sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.16.17:
     resolution: {integrity: sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==}
     engines: {node: '>=12'}
     cpu: [x64]
@@ -39,7 +46,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64/0.16.17:
+  /@esbuild/darwin-arm64@0.16.17:
     resolution: {integrity: sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==}
     engines: {node: '>=12'}
     cpu: [arm64]
@@ -48,7 +55,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-x64/0.16.17:
+  /@esbuild/darwin-x64@0.16.17:
     resolution: {integrity: sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==}
     engines: {node: '>=12'}
     cpu: [x64]
@@ -57,7 +64,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64/0.16.17:
+  /@esbuild/freebsd-arm64@0.16.17:
     resolution: {integrity: sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==}
     engines: {node: '>=12'}
     cpu: [arm64]
@@ -66,7 +73,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-x64/0.16.17:
+  /@esbuild/freebsd-x64@0.16.17:
     resolution: {integrity: sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==}
     engines: {node: '>=12'}
     cpu: [x64]
@@ -75,16 +82,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm/0.16.17:
-    resolution: {integrity: sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-arm64/0.16.17:
+  /@esbuild/linux-arm64@0.16.17:
     resolution: {integrity: sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==}
     engines: {node: '>=12'}
     cpu: [arm64]
@@ -93,7 +91,16 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32/0.16.17:
+  /@esbuild/linux-arm@0.16.17:
+    resolution: {integrity: sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.16.17:
     resolution: {integrity: sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==}
     engines: {node: '>=12'}
     cpu: [ia32]
@@ -102,7 +109,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-loong64/0.16.17:
+  /@esbuild/linux-loong64@0.16.17:
     resolution: {integrity: sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==}
     engines: {node: '>=12'}
     cpu: [loong64]
@@ -111,7 +118,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el/0.16.17:
+  /@esbuild/linux-mips64el@0.16.17:
     resolution: {integrity: sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==}
     engines: {node: '>=12'}
     cpu: [mips64el]
@@ -120,7 +127,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ppc64/0.16.17:
+  /@esbuild/linux-ppc64@0.16.17:
     resolution: {integrity: sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==}
     engines: {node: '>=12'}
     cpu: [ppc64]
@@ -129,7 +136,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64/0.16.17:
+  /@esbuild/linux-riscv64@0.16.17:
     resolution: {integrity: sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==}
     engines: {node: '>=12'}
     cpu: [riscv64]
@@ -138,7 +145,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-s390x/0.16.17:
+  /@esbuild/linux-s390x@0.16.17:
     resolution: {integrity: sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==}
     engines: {node: '>=12'}
     cpu: [s390x]
@@ -147,7 +154,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-x64/0.16.17:
+  /@esbuild/linux-x64@0.16.17:
     resolution: {integrity: sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==}
     engines: {node: '>=12'}
     cpu: [x64]
@@ -156,7 +163,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/netbsd-x64/0.16.17:
+  /@esbuild/netbsd-x64@0.16.17:
     resolution: {integrity: sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==}
     engines: {node: '>=12'}
     cpu: [x64]
@@ -165,7 +172,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/openbsd-x64/0.16.17:
+  /@esbuild/openbsd-x64@0.16.17:
     resolution: {integrity: sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==}
     engines: {node: '>=12'}
     cpu: [x64]
@@ -174,7 +181,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/sunos-x64/0.16.17:
+  /@esbuild/sunos-x64@0.16.17:
     resolution: {integrity: sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==}
     engines: {node: '>=12'}
     cpu: [x64]
@@ -183,7 +190,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-arm64/0.16.17:
+  /@esbuild/win32-arm64@0.16.17:
     resolution: {integrity: sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==}
     engines: {node: '>=12'}
     cpu: [arm64]
@@ -192,7 +199,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32/0.16.17:
+  /@esbuild/win32-ia32@0.16.17:
     resolution: {integrity: sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==}
     engines: {node: '>=12'}
     cpu: [ia32]
@@ -201,7 +208,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-x64/0.16.17:
+  /@esbuild/win32-x64@0.16.17:
     resolution: {integrity: sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==}
     engines: {node: '>=12'}
     cpu: [x64]
@@ -210,21 +217,49 @@ packages:
     dev: true
     optional: true
 
-  /@types/chai-subset/1.3.3:
+  /@types/chai-subset@1.3.3:
     resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
     dependencies:
       '@types/chai': 4.3.4
     dev: true
 
-  /@types/chai/4.3.4:
+  /@types/chai@4.3.4:
     resolution: {integrity: sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==}
     dev: true
 
-  /@types/node/18.14.6:
+  /@types/fs-extra@8.1.2:
+    resolution: {integrity: sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==}
+    dependencies:
+      '@types/node': 18.14.6
+    dev: true
+
+  /@types/glob@8.1.0:
+    resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
+    dependencies:
+      '@types/minimatch': 5.1.2
+      '@types/node': 18.14.6
+    dev: true
+
+  /@types/minimatch@3.0.5:
+    resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
+    dev: true
+
+  /@types/minimatch@5.1.2:
+    resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
+    dev: true
+
+  /@types/node@18.14.6:
     resolution: {integrity: sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==}
     dev: true
 
-  /@vitest/expect/0.28.5:
+  /@types/rimraf@2.0.5:
+    resolution: {integrity: sha512-YyP+VfeaqAyFmXoTh3HChxOQMyjByRMsHU7kc5KOJkSlXudhMhQIALbYV7rHh/l8d2lX3VUQzprrcAgWdRuU8g==}
+    dependencies:
+      '@types/glob': 8.1.0
+      '@types/node': 18.14.6
+    dev: true
+
+  /@vitest/expect@0.28.5:
     resolution: {integrity: sha512-gqTZwoUTwepwGIatnw4UKpQfnoyV0Z9Czn9+Lo2/jLIt4/AXLTn+oVZxlQ7Ng8bzcNkR+3DqLJ08kNr8jRmdNQ==}
     dependencies:
       '@vitest/spy': 0.28.5
@@ -232,7 +267,7 @@ packages:
       chai: 4.3.7
     dev: true
 
-  /@vitest/runner/0.28.5:
+  /@vitest/runner@0.28.5:
     resolution: {integrity: sha512-NKkHtLB+FGjpp5KmneQjTcPLWPTDfB7ie+MmF1PnUBf/tGe2OjGxWyB62ySYZ25EYp9krR5Bw0YPLS/VWh1QiA==}
     dependencies:
       '@vitest/utils': 0.28.5
@@ -240,13 +275,13 @@ packages:
       pathe: 1.1.0
     dev: true
 
-  /@vitest/spy/0.28.5:
+  /@vitest/spy@0.28.5:
     resolution: {integrity: sha512-7if6rsHQr9zbmvxN7h+gGh2L9eIIErgf8nSKYDlg07HHimCxp4H6I/X/DPXktVPPLQfiZ1Cw2cbDIx9fSqDjGw==}
     dependencies:
       tinyspy: 1.1.1
     dev: true
 
-  /@vitest/utils/0.28.5:
+  /@vitest/utils@0.28.5:
     resolution: {integrity: sha512-UyZdYwdULlOa4LTUSwZ+Paz7nBHGTT72jKwdFSV4IjHF1xsokp+CabMdhjvVhYwkLfO88ylJT46YMilnkSARZA==}
     dependencies:
       cli-truncate: 3.1.0
@@ -256,51 +291,74 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /acorn-walk/8.2.0:
+  /acorn-walk@8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
     engines: {node: '>=0.4.0'}
     dev: true
 
-  /acorn/8.8.2:
+  /acorn@8.8.2:
     resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
 
-  /ansi-regex/5.0.1:
+  /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
     dev: true
 
-  /ansi-regex/6.0.1:
+  /ansi-regex@6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
     dev: true
 
-  /ansi-styles/5.2.0:
+  /ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
     dev: true
 
-  /ansi-styles/6.2.1:
+  /ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
     dev: true
 
-  /assertion-error/1.1.0:
+  /assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
 
-  /buffer-from/1.1.2:
+  /balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: true
+
+  /bin-links@3.0.3:
+    resolution: {integrity: sha512-zKdnMPWEdh4F5INR07/eBrodC7QrF5JKvqskjz/ZZRXg5YSAZIbn8zGhbhUrElzHBZ2fvEQdOU59RHcTG3GiwA==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dependencies:
+      cmd-shim: 5.0.0
+      mkdirp-infer-owner: 2.0.0
+      npm-normalize-package-bin: 2.0.0
+      read-cmd-shim: 3.0.1
+      rimraf: 3.0.2
+      write-file-atomic: 4.0.2
+    dev: true
+
+  /brace-expansion@1.1.11:
+    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    dev: true
+
+  /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
     dev: true
 
-  /cac/6.7.14:
+  /cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
     dev: true
 
-  /chai/4.3.7:
+  /chai@4.3.7:
     resolution: {integrity: sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==}
     engines: {node: '>=4'}
     dependencies:
@@ -313,11 +371,16 @@ packages:
       type-detect: 4.0.8
     dev: true
 
-  /check-error/1.0.2:
+  /check-error@1.0.2:
     resolution: {integrity: sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==}
     dev: true
 
-  /cli-truncate/3.1.0:
+  /chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /cli-truncate@3.1.0:
     resolution: {integrity: sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
@@ -325,7 +388,18 @@ packages:
       string-width: 5.1.2
     dev: true
 
-  /cross-spawn/7.0.3:
+  /cmd-shim@5.0.0:
+    resolution: {integrity: sha512-qkCtZ59BidfEwHltnJwkyVZn+XQojdAySM1D1gSeh11Z4pW1Kpolkyo53L5noc0nrxmIvyFwTmJRo4xs7FFLPw==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dependencies:
+      mkdirp-infer-owner: 2.0.0
+    dev: true
+
+  /concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    dev: true
+
+  /cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
     dependencies:
@@ -334,7 +408,7 @@ packages:
       which: 2.0.2
     dev: true
 
-  /debug/4.3.4:
+  /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
@@ -346,27 +420,36 @@ packages:
       ms: 2.1.2
     dev: true
 
-  /deep-eql/4.1.3:
+  /deep-eql@4.1.3:
     resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
     engines: {node: '>=6'}
     dependencies:
       type-detect: 4.0.8
     dev: true
 
-  /diff/5.1.0:
+  /deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /diff@5.1.0:
     resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
     engines: {node: '>=0.3.1'}
     dev: true
 
-  /eastasianwidth/0.2.0:
+  /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
 
-  /emoji-regex/9.2.2:
+  /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
     dev: true
 
-  /esbuild/0.16.17:
+  /ensure-posix-path@1.1.1:
+    resolution: {integrity: sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw==}
+    dev: true
+
+  /esbuild@0.16.17:
     resolution: {integrity: sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==}
     engines: {node: '>=12'}
     hasBin: true
@@ -396,7 +479,7 @@ packages:
       '@esbuild/win32-x64': 0.16.17
     dev: true
 
-  /execa/5.1.1:
+  /execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
     dependencies:
@@ -411,7 +494,45 @@ packages:
       strip-final-newline: 2.0.0
     dev: true
 
-  /fsevents/2.3.2:
+  /fixturify-project@5.2.0:
+    resolution: {integrity: sha512-7H20FpTbA8P586gS/5SuVmKYLBdOs1oPTF7R2If5lhlcmI+ht48p9atbBtD6kOIuRUPrx6W2yLxUCToBl8W22w==}
+    engines: {node: '>= 14.*'}
+    dependencies:
+      bin-links: 3.0.3
+      deepmerge: 4.3.1
+      fixturify: 2.1.1
+      resolve-package-path: 4.0.3
+      tmp: 0.0.33
+      type-fest: 2.19.0
+      walk-sync: 3.0.0
+    dev: true
+
+  /fixturify@2.1.1:
+    resolution: {integrity: sha512-SRgwIMXlxkb6AUgaVjIX+jCEqdhyXu9hah7mcK+lWynjKtX73Ux1TDv71B7XyaQ+LJxkYRHl5yCL8IycAvQRUw==}
+    engines: {node: 10.* || >= 12.*}
+    dependencies:
+      '@types/fs-extra': 8.1.2
+      '@types/minimatch': 3.0.5
+      '@types/rimraf': 2.0.5
+      fs-extra: 8.1.0
+      matcher-collection: 2.0.1
+      walk-sync: 2.2.0
+    dev: true
+
+  /fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+    dev: true
+
+  /fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    dev: true
+
+  /fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
@@ -419,76 +540,152 @@ packages:
     dev: true
     optional: true
 
-  /function-bind/1.1.1:
+  /function-bind@1.1.1:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
     dev: true
 
-  /get-func-name/2.0.0:
+  /get-func-name@2.0.0:
     resolution: {integrity: sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==}
     dev: true
 
-  /get-stream/6.0.1:
+  /get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
     dev: true
 
-  /has/1.0.3:
+  /glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    dev: true
+
+  /graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+    dev: true
+
+  /has@1.0.3:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
     dev: true
 
-  /human-signals/2.1.0:
+  /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
     dev: true
 
-  /is-core-module/2.11.0:
+  /imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+    dev: true
+
+  /infer-owner@1.0.4:
+    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
+    dev: true
+
+  /inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+    dev: true
+
+  /inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: true
+
+  /is-core-module@2.11.0:
     resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
     dependencies:
       has: 1.0.3
     dev: true
 
-  /is-fullwidth-code-point/4.0.0:
+  /is-fullwidth-code-point@4.0.0:
     resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
     engines: {node: '>=12'}
     dev: true
 
-  /is-stream/2.0.1:
+  /is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
     dev: true
 
-  /isexe/2.0.0:
+  /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
-  /jsonc-parser/3.2.0:
+  /json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+    dev: true
+
+  /jsonc-parser@3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
     dev: true
 
-  /local-pkg/0.4.3:
+  /jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+    optionalDependencies:
+      graceful-fs: 4.2.11
+    dev: true
+
+  /local-pkg@0.4.3:
     resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
     engines: {node: '>=14'}
     dev: true
 
-  /loupe/2.3.6:
+  /loupe@2.3.6:
     resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
     dependencies:
       get-func-name: 2.0.0
     dev: true
 
-  /merge-stream/2.0.0:
+  /matcher-collection@2.0.1:
+    resolution: {integrity: sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+    dependencies:
+      '@types/minimatch': 3.0.5
+      minimatch: 3.1.2
+    dev: true
+
+  /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
     dev: true
 
-  /mimic-fn/2.1.0:
+  /mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
     dev: true
 
-  /mlly/1.1.1:
+  /minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+    dependencies:
+      brace-expansion: 1.1.11
+    dev: true
+
+  /mkdirp-infer-owner@2.0.0:
+    resolution: {integrity: sha512-sdqtiFt3lkOaYvTXSRIUjkIdPTcxgv5+fgqYE/5qgwdw12cOrAuzzgzvVExIkH/ul1oeHN3bCLOWSG3XOqbKKw==}
+    engines: {node: '>=10'}
+    dependencies:
+      chownr: 2.0.0
+      infer-owner: 1.0.4
+      mkdirp: 1.0.4
+    dev: true
+
+  /mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: true
+
+  /mlly@1.1.1:
     resolution: {integrity: sha512-Jnlh4W/aI4GySPo6+DyTN17Q75KKbLTyFK8BrGhjNP4rxuUjbRWhE6gHg3bs33URWAF44FRm7gdQA348i3XxRw==}
     dependencies:
       acorn: 8.8.2
@@ -497,59 +694,92 @@ packages:
       ufo: 1.1.1
     dev: true
 
-  /ms/2.1.2:
+  /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
 
-  /nanoid/3.3.4:
+  /nanoid@3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: true
 
-  /npm-run-path/4.0.1:
+  /npm-normalize-package-bin@2.0.0:
+    resolution: {integrity: sha512-awzfKUO7v0FscrSpRoogyNm0sajikhBWpU0QMrW09AMi9n1PoKU6WaIqUzuJSQnpciZZmJ/jMZ2Egfmb/9LiWQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dev: true
+
+  /npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
     dependencies:
       path-key: 3.1.1
     dev: true
 
-  /onetime/5.1.2:
+  /once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+    dependencies:
+      wrappy: 1.0.2
+    dev: true
+
+  /onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
     dependencies:
       mimic-fn: 2.1.0
     dev: true
 
-  /p-limit/4.0.0:
+  /os-tmpdir@1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /p-limit@4.0.0:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       yocto-queue: 1.0.0
     dev: true
 
-  /path-key/3.1.1:
+  /path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
     dev: true
 
-  /path-parse/1.0.7:
+  /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: true
 
-  /pathe/1.1.0:
+  /path-root-regex@0.1.2:
+    resolution: {integrity: sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /path-root@0.1.1:
+    resolution: {integrity: sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      path-root-regex: 0.1.2
+    dev: true
+
+  /pathe@1.1.0:
     resolution: {integrity: sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==}
     dev: true
 
-  /pathval/1.1.1:
+  /pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: true
 
-  /picocolors/1.0.0:
+  /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
     dev: true
 
-  /pkg-types/1.0.2:
+  /pkg-types@1.0.2:
     resolution: {integrity: sha512-hM58GKXOcj8WTqUXnsQyJYXdeAPbythQgEF3nTcEo+nkD49chjQ9IKm/QJy9xf6JakXptz86h7ecP2024rrLaQ==}
     dependencies:
       jsonc-parser: 3.2.0
@@ -557,7 +787,7 @@ packages:
       pathe: 1.1.0
     dev: true
 
-  /postcss/8.4.21:
+  /postcss@8.4.21:
     resolution: {integrity: sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
@@ -566,7 +796,7 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
-  /pretty-format/27.5.1:
+  /pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
@@ -575,11 +805,23 @@ packages:
       react-is: 17.0.2
     dev: true
 
-  /react-is/17.0.2:
+  /react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
     dev: true
 
-  /resolve/1.22.1:
+  /read-cmd-shim@3.0.1:
+    resolution: {integrity: sha512-kEmDUoYf/CDy8yZbLTmhB1X9kkjf9Q80PCNsDMb7ufrGd6zZSQA1+UyjrO+pZm5K/S4OXCWJeiIt1JA8kAsa6g==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dev: true
+
+  /resolve-package-path@4.0.3:
+    resolution: {integrity: sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==}
+    engines: {node: '>= 12'}
+    dependencies:
+      path-root: 0.1.1
+    dev: true
+
+  /resolve@1.22.1:
     resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
     hasBin: true
     dependencies:
@@ -588,7 +830,14 @@ packages:
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
 
-  /rollup/3.18.0:
+  /rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    hasBin: true
+    dependencies:
+      glob: 7.2.3
+    dev: true
+
+  /rollup@3.18.0:
     resolution: {integrity: sha512-J8C6VfEBjkvYPESMQYxKHxNOh4A5a3FlP+0BETGo34HEcE4eTlgCrO2+eWzlu2a/sHs2QUkZco+wscH7jhhgWg==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
@@ -596,27 +845,27 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /shebang-command/2.0.0:
+  /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
     dev: true
 
-  /shebang-regex/3.0.0:
+  /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
     dev: true
 
-  /siginfo/2.0.0:
+  /siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
     dev: true
 
-  /signal-exit/3.0.7:
+  /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
     dev: true
 
-  /slice-ansi/5.0.0:
+  /slice-ansi@5.0.0:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
     engines: {node: '>=12'}
     dependencies:
@@ -624,32 +873,32 @@ packages:
       is-fullwidth-code-point: 4.0.0
     dev: true
 
-  /source-map-js/1.0.2:
+  /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /source-map-support/0.5.21:
+  /source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
     dev: true
 
-  /source-map/0.6.1:
+  /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /stackback/0.0.2:
+  /stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
 
-  /std-env/3.3.2:
+  /std-env@3.3.2:
     resolution: {integrity: sha512-uUZI65yrV2Qva5gqE0+A7uVAvO40iPo6jGhs7s8keRfHCmtg+uB2X6EiLGCI9IgL1J17xGhvoOqSz79lzICPTA==}
     dev: true
 
-  /string-width/5.1.2:
+  /string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
     dependencies:
@@ -658,53 +907,70 @@ packages:
       strip-ansi: 7.0.1
     dev: true
 
-  /strip-ansi/7.0.1:
+  /strip-ansi@7.0.1:
     resolution: {integrity: sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==}
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.0.1
     dev: true
 
-  /strip-final-newline/2.0.0:
+  /strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
     dev: true
 
-  /strip-literal/1.0.1:
+  /strip-literal@1.0.1:
     resolution: {integrity: sha512-QZTsipNpa2Ppr6v1AmJHESqJ3Uz247MUS0OjrnnZjFAvEoWqxuyFuXn2xLgMtRnijJShAa1HL0gtJyUs7u7n3Q==}
     dependencies:
       acorn: 8.8.2
     dev: true
 
-  /supports-preserve-symlinks-flag/1.0.0:
+  /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
     dev: true
 
-  /tinybench/2.3.1:
+  /tinybench@2.3.1:
     resolution: {integrity: sha512-hGYWYBMPr7p4g5IarQE7XhlyWveh1EKhy4wUBS1LrHXCKYgvz+4/jCqgmJqZxxldesn05vccrtME2RLLZNW7iA==}
     dev: true
 
-  /tinypool/0.3.1:
+  /tinypool@0.3.1:
     resolution: {integrity: sha512-zLA1ZXlstbU2rlpA4CIeVaqvWq41MTWqLY3FfsAXgC8+f7Pk7zroaJQxDgxn1xNudKW6Kmj4808rPFShUlIRmQ==}
     engines: {node: '>=14.0.0'}
     dev: true
 
-  /tinyspy/1.1.1:
+  /tinyspy@1.1.1:
     resolution: {integrity: sha512-UVq5AXt/gQlti7oxoIg5oi/9r0WpF7DGEVwXgqWSMmyN16+e3tl5lIvTaOpJ3TAtu5xFzWccFRM4R5NaWHF+4g==}
     engines: {node: '>=14.0.0'}
     dev: true
 
-  /type-detect/4.0.8:
+  /tmp@0.0.33:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
+    engines: {node: '>=0.6.0'}
+    dependencies:
+      os-tmpdir: 1.0.2
+    dev: true
+
+  /type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
     dev: true
 
-  /ufo/1.1.1:
+  /type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
+    dev: true
+
+  /ufo@1.1.1:
     resolution: {integrity: sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==}
     dev: true
 
-  /vite-node/0.28.5_@types+node@18.14.6:
+  /universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
+    dev: true
+
+  /vite-node@0.28.5(@types/node@18.14.6):
     resolution: {integrity: sha512-LmXb9saMGlrMZbXTvOveJKwMTBTNUH66c8rJnQ0ZPNX+myPEol64+szRzXtV5ORb0Hb/91yq+/D3oERoyAt6LA==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
@@ -716,7 +982,7 @@ packages:
       picocolors: 1.0.0
       source-map: 0.6.1
       source-map-support: 0.5.21
-      vite: 4.1.4_@types+node@18.14.6
+      vite: 4.1.4(@types/node@18.14.6)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -727,40 +993,7 @@ packages:
       - terser
     dev: true
 
-  /vite/4.1.4:
-    resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.16.17
-      postcss: 8.4.21
-      resolve: 1.22.1
-      rollup: 3.18.0
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
-  /vite/4.1.4_@types+node@18.14.6:
+  /vite@4.1.4(@types/node@18.14.6):
     resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -794,7 +1027,7 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitest/0.28.5:
+  /vitest@0.28.5:
     resolution: {integrity: sha512-pyCQ+wcAOX7mKMcBNkzDwEHRGqQvHUl0XnoHR+3Pb1hytAHISgSxv9h0gUiSiYtISXUU3rMrKiKzFYDrI6ZIHA==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
@@ -837,8 +1070,8 @@ packages:
       tinybench: 2.3.1
       tinypool: 0.3.1
       tinyspy: 1.1.1
-      vite: 4.1.4_@types+node@18.14.6
-      vite-node: 0.28.5_@types+node@18.14.6
+      vite: 4.1.4(@types/node@18.14.6)
+      vite-node: 0.28.5(@types/node@18.14.6)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -849,7 +1082,27 @@ packages:
       - terser
     dev: true
 
-  /which/2.0.2:
+  /walk-sync@2.2.0:
+    resolution: {integrity: sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==}
+    engines: {node: 8.* || >= 10.*}
+    dependencies:
+      '@types/minimatch': 3.0.5
+      ensure-posix-path: 1.1.1
+      matcher-collection: 2.0.1
+      minimatch: 3.1.2
+    dev: true
+
+  /walk-sync@3.0.0:
+    resolution: {integrity: sha512-41TvKmDGVpm2iuH7o+DAOt06yyu/cSHpX3uzAwetzASvlNtVddgIjXIb2DfB/Wa20B1Jo86+1Dv1CraSU7hWdw==}
+    engines: {node: 10.* || >= 12.*}
+    dependencies:
+      '@types/minimatch': 3.0.5
+      ensure-posix-path: 1.1.1
+      matcher-collection: 2.0.1
+      minimatch: 3.1.2
+    dev: true
+
+  /which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
@@ -857,7 +1110,7 @@ packages:
       isexe: 2.0.0
     dev: true
 
-  /why-is-node-running/2.2.2:
+  /why-is-node-running@2.2.2:
     resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
     engines: {node: '>=8'}
     hasBin: true
@@ -866,7 +1119,19 @@ packages:
       stackback: 0.0.2
     dev: true
 
-  /yocto-queue/1.0.0:
+  /wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    dev: true
+
+  /write-file-atomic@4.0.2:
+    resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 3.0.7
+    dev: true
+
+  /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
     dev: true

--- a/test/__snapshots__/ember.test.js.snap
+++ b/test/__snapshots__/ember.test.js.snap
@@ -28,3 +28,112 @@ exports[`validation-test ember@3.28 LTS > graph 1`] = `
 [DATA] tests/unit/models/rental-test.js
 [SUCCESS] Analyzing project dependency graph"
 `;
+
+exports[`validation-test ember@3.28 LTS > migrate 1`] = `
+"import Component from '@glimmer/component';
+import ENV from 'super-rentals/config/environment';
+
+const MAPBOX_API = 'https://api.mapbox.com/styles/v1/mapbox/streets-v11/static';
+
+// @ts-expect-error @rehearsal TODO TS2314: Generic type 'Component<Args, S>' requires 2 type argument(s).
+export default class MapComponent extends Component {
+  get src() {
+    // @ts-expect-error @rehearsal TODO TS2339: Property 'args' does not exist on type 'MapComponent'.
+    let { lng, lat, width, height, zoom } = this.args;
+
+    let coordinates = \`\${lng},\${lat},\${zoom}\`;
+    let dimensions = \`\${width}x\${height}\`;
+    let accessToken = \`access_token=\${this.token}\`;
+
+    return \`\${MAPBOX_API}/\${coordinates}/\${dimensions}@2x?\${accessToken}\`;
+  }
+
+  get token() {
+    return encodeURIComponent(ENV.MAPBOX_ACCESS_TOKEN);
+  }
+}
+"
+`;
+
+exports[`validation-test ember@3.28 LTS > migrate 2`] = `
+"import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+const TWEET_INTENT = 'https://twitter.com/intent/tweet';
+
+// @ts-expect-error @rehearsal TODO TS2314: Generic type 'Component<Args, S>' requires 2 type argument(s).
+export default class ShareButtonComponent extends Component {
+  // @ts-expect-error @rehearsal TODO TS2564: Property 'router' has no initializer and is not definitely assigned in the constructor.
+  @service router: { currentURL: string | URL };
+  // @ts-expect-error @rehearsal TODO TS2564: Property 'locale' has no initializer and is not definitely assigned in the constructor.
+  @service locale: { current: () => string };
+
+  get currentURL() {
+    return new URL(this.router.currentURL, window.location.origin);
+  }
+
+  get shareURL() {
+    let url = new URL(TWEET_INTENT);
+
+    // @ts-expect-error @rehearsal TODO TS2345: Argument of type 'URL' is not assignable to parameter of type 'string'. Consider verifying both types, using type assertion: '( this.currentURL as string)', or using type guard: 'if ( this.currentURL instanceof string) { ... }'.
+    url.searchParams.set('url', this.currentURL);
+
+    // @ts-expect-error @rehearsal TODO TS2339: Property 'args' does not exist on type 'ShareButtonComponent'.
+    if (this.args.text) {
+      // @ts-expect-error @rehearsal TODO TS2339: Property 'args' does not exist on type 'ShareButtonComponent'.
+      url.searchParams.set('text', this.args.text);
+    }
+
+    // @ts-expect-error @rehearsal TODO TS2339: Property 'args' does not exist on type 'ShareButtonComponent'.
+    if (this.args.hashtags) {
+      // @ts-expect-error @rehearsal TODO TS2339: Property 'args' does not exist on type 'ShareButtonComponent'.
+      url.searchParams.set('hashtags', this.args.hashtags);
+    }
+
+    // @ts-expect-error @rehearsal TODO TS2339: Property 'args' does not exist on type 'ShareButtonComponent'.
+    if (this.args.via) {
+      // @ts-expect-error @rehearsal TODO TS2339: Property 'args' does not exist on type 'ShareButtonComponent'.
+      url.searchParams.set('via', this.args.via);
+    }
+
+    url.searchParams.set('locale', this.locale.current());
+
+    return url;
+  }
+}
+"
+`;
+
+exports[`validation-test ember@3.28 LTS > migrate 3`] = `
+"import Model, { attr } from '@ember-data/model';
+
+const COMMUNITY_CATEGORIES = ['Condo', 'Townhouse', 'Apartment'];
+
+export default class RentalModel extends Model {
+  // @ts-expect-error @rehearsal TODO TS7008: Member 'title' implicitly has an 'any' type.
+  @attr title;
+  // @ts-expect-error @rehearsal TODO TS7008: Member 'owner' implicitly has an 'any' type.
+  @attr owner;
+  // @ts-expect-error @rehearsal TODO TS7008: Member 'city' implicitly has an 'any' type.
+  @attr city;
+  // @ts-expect-error @rehearsal TODO TS7008: Member 'location' implicitly has an 'any' type.
+  @attr location;
+  // @ts-expect-error @rehearsal TODO TS2564: Property 'category' has no initializer and is not definitely assigned in the constructor.
+  @attr category: string;
+  // @ts-expect-error @rehearsal TODO TS7008: Member 'image' implicitly has an 'any' type.
+  @attr image;
+  // @ts-expect-error @rehearsal TODO TS7008: Member 'bedrooms' implicitly has an 'any' type.
+  @attr bedrooms;
+  // @ts-expect-error @rehearsal TODO TS7008: Member 'description' implicitly has an 'any' type.
+  @attr description;
+
+  get type() {
+    if (COMMUNITY_CATEGORIES.includes(this.category)) {
+      return 'Community';
+    } else {
+      return 'Standalone';
+    }
+  }
+}
+"
+`;

--- a/test/__snapshots__/ember.test.js.snap
+++ b/test/__snapshots__/ember.test.js.snap
@@ -1,0 +1,30 @@
+// Vitest Snapshot v1
+
+exports[`validation-test ember@3.28 LTS > graph 1`] = `
+"[STARTED] Analyzing project dependency graph
+[DATA] Graph order for '.':
+[DATA] 
+[DATA] app/adapters/application.js
+[DATA] app/app.js
+[DATA] app/components/map.js
+[DATA] app/components/rental/image.js
+[DATA] app/components/rentals.js
+[DATA] app/components/rentals/filter.js
+[DATA] app/services/locale.js
+[DATA] app/components/share-button.js
+[DATA] app/models/rental.js
+[DATA] app/router.js
+[DATA] app/routes/rental.js
+[DATA] app/serializers/application.js
+[DATA] tests/acceptance/super-rentals-test.js
+[DATA] tests/integration/components/jumbo-test.js
+[DATA] tests/integration/components/map-test.js
+[DATA] tests/integration/components/rental-test.js
+[DATA] tests/integration/components/rental/detailed-test.js
+[DATA] tests/integration/components/rental/image-test.js
+[DATA] tests/integration/components/rentals-test.js
+[DATA] tests/integration/components/share-button-test.js
+[DATA] tests/test-helper.js
+[DATA] tests/unit/models/rental-test.js
+[SUCCESS] Analyzing project dependency graph"
+`;

--- a/test/__snapshots__/ember.test.js.snap
+++ b/test/__snapshots__/ember.test.js.snap
@@ -6,6 +6,7 @@ exports[`validation-test ember@3.28 LTS > graph 1`] = `
 [DATA] 
 [DATA] app/adapters/application.js
 [DATA] app/app.js
+[DATA] app/components/HelloWorld.gjs
 [DATA] app/components/map.js
 [DATA] app/components/rental/image.js
 [DATA] app/components/rentals.js
@@ -136,12 +137,27 @@ export default class RentalModel extends Model {
 "
 `;
 
+exports[`validation-test ember@3.28 LTS > migrate 4`] = `
+"import Component from '@glimmer/component';
+
+export default class Hello extends Component {
+  name = 'world';
+
+  <template>
+    {{! @glint-expect-error @rehearsal TODO TS2339: Property 'age' does not exist on type '{}'. }}
+    <span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>
+  </template>
+}
+"
+`;
+
 exports[`validation-test ember@4.4 LTS > graph 1`] = `
 "[STARTED] Analyzing project dependency graph
 [DATA] Graph order for '.':
 [DATA] 
 [DATA] app/adapters/application.js
 [DATA] app/app.js
+[DATA] app/components/HelloWorld.gjs
 [DATA] app/components/map.js
 [DATA] app/components/rental/image.js
 [DATA] app/components/rentals.js
@@ -268,6 +284,20 @@ export default class RentalModel extends Model {
       return 'Standalone';
     }
   }
+}
+"
+`;
+
+exports[`validation-test ember@4.4 LTS > migrate 4`] = `
+"import Component from '@glimmer/component';
+
+export default class Hello extends Component {
+  name = 'world';
+
+  <template>
+    {{! @glint-expect-error @rehearsal TODO TS2339: Property 'age' does not exist on type '{}'. }}
+    <span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>
+  </template>
 }
 "
 `;

--- a/test/__snapshots__/ember.test.js.snap
+++ b/test/__snapshots__/ember.test.js.snap
@@ -35,10 +35,9 @@ import ENV from 'super-rentals/config/environment';
 
 const MAPBOX_API = 'https://api.mapbox.com/styles/v1/mapbox/streets-v11/static';
 
-// @ts-expect-error @rehearsal TODO TS2314: Generic type 'Component<Args, S>' requires 2 type argument(s).
 export default class MapComponent extends Component {
   get src() {
-    // @ts-expect-error @rehearsal TODO TS2339: Property 'args' does not exist on type 'MapComponent'.
+    // @ts-expect-error @rehearsal TODO TS2339: Property 'lng' does not exist on type 'Readonly<EmptyObject>'.
     let { lng, lat, width, height, zoom } = this.args;
 
     let coordinates = \`\${lng},\${lat},\${zoom}\`;
@@ -61,7 +60,6 @@ import Component from '@glimmer/component';
 
 const TWEET_INTENT = 'https://twitter.com/intent/tweet';
 
-// @ts-expect-error @rehearsal TODO TS2314: Generic type 'Component<Args, S>' requires 2 type argument(s).
 export default class ShareButtonComponent extends Component {
   // @ts-expect-error @rehearsal TODO TS2564: Property 'router' has no initializer and is not definitely assigned in the constructor.
   @service router: { currentURL: string | URL };
@@ -78,21 +76,21 @@ export default class ShareButtonComponent extends Component {
     // @ts-expect-error @rehearsal TODO TS2345: Argument of type 'URL' is not assignable to parameter of type 'string'. Consider verifying both types, using type assertion: '( this.currentURL as string)', or using type guard: 'if ( this.currentURL instanceof string) { ... }'.
     url.searchParams.set('url', this.currentURL);
 
-    // @ts-expect-error @rehearsal TODO TS2339: Property 'args' does not exist on type 'ShareButtonComponent'.
+    // @ts-expect-error @rehearsal TODO TS2339: Property 'text' does not exist on type 'Readonly<EmptyObject>'.
     if (this.args.text) {
-      // @ts-expect-error @rehearsal TODO TS2339: Property 'args' does not exist on type 'ShareButtonComponent'.
+      // @ts-expect-error @rehearsal TODO TS2339: Property 'text' does not exist on type 'Readonly<EmptyObject>'.
       url.searchParams.set('text', this.args.text);
     }
 
-    // @ts-expect-error @rehearsal TODO TS2339: Property 'args' does not exist on type 'ShareButtonComponent'.
+    // @ts-expect-error @rehearsal TODO TS2339: Property 'hashtags' does not exist on type 'Readonly<EmptyObject>'.
     if (this.args.hashtags) {
-      // @ts-expect-error @rehearsal TODO TS2339: Property 'args' does not exist on type 'ShareButtonComponent'.
+      // @ts-expect-error @rehearsal TODO TS2339: Property 'hashtags' does not exist on type 'Readonly<EmptyObject>'.
       url.searchParams.set('hashtags', this.args.hashtags);
     }
 
-    // @ts-expect-error @rehearsal TODO TS2339: Property 'args' does not exist on type 'ShareButtonComponent'.
+    // @ts-expect-error @rehearsal TODO TS2339: Property 'via' does not exist on type 'Readonly<EmptyObject>'.
     if (this.args.via) {
-      // @ts-expect-error @rehearsal TODO TS2339: Property 'args' does not exist on type 'ShareButtonComponent'.
+      // @ts-expect-error @rehearsal TODO TS2339: Property 'via' does not exist on type 'Readonly<EmptyObject>'.
       url.searchParams.set('via', this.args.via);
     }
 
@@ -105,6 +103,142 @@ export default class ShareButtonComponent extends Component {
 `;
 
 exports[`validation-test ember@3.28 LTS > migrate 3`] = `
+"import Model, { attr } from '@ember-data/model';
+
+const COMMUNITY_CATEGORIES = ['Condo', 'Townhouse', 'Apartment'];
+
+export default class RentalModel extends Model {
+  // @ts-expect-error @rehearsal TODO TS7008: Member 'title' implicitly has an 'any' type.
+  @attr title;
+  // @ts-expect-error @rehearsal TODO TS7008: Member 'owner' implicitly has an 'any' type.
+  @attr owner;
+  // @ts-expect-error @rehearsal TODO TS7008: Member 'city' implicitly has an 'any' type.
+  @attr city;
+  // @ts-expect-error @rehearsal TODO TS7008: Member 'location' implicitly has an 'any' type.
+  @attr location;
+  // @ts-expect-error @rehearsal TODO TS2564: Property 'category' has no initializer and is not definitely assigned in the constructor.
+  @attr category: string;
+  // @ts-expect-error @rehearsal TODO TS7008: Member 'image' implicitly has an 'any' type.
+  @attr image;
+  // @ts-expect-error @rehearsal TODO TS7008: Member 'bedrooms' implicitly has an 'any' type.
+  @attr bedrooms;
+  // @ts-expect-error @rehearsal TODO TS7008: Member 'description' implicitly has an 'any' type.
+  @attr description;
+
+  get type() {
+    if (COMMUNITY_CATEGORIES.includes(this.category)) {
+      return 'Community';
+    } else {
+      return 'Standalone';
+    }
+  }
+}
+"
+`;
+
+exports[`validation-test ember@4.4 LTS > graph 1`] = `
+"[STARTED] Analyzing project dependency graph
+[DATA] Graph order for '.':
+[DATA] 
+[DATA] app/adapters/application.js
+[DATA] app/app.js
+[DATA] app/components/map.js
+[DATA] app/components/rental/image.js
+[DATA] app/components/rentals.js
+[DATA] app/components/rentals/filter.js
+[DATA] app/services/locale.js
+[DATA] app/components/share-button.js
+[DATA] app/models/rental.js
+[DATA] app/router.js
+[DATA] app/routes/rental.js
+[DATA] app/serializers/application.js
+[DATA] tests/acceptance/super-rentals-test.js
+[DATA] tests/integration/components/jumbo-test.js
+[DATA] tests/integration/components/map-test.js
+[DATA] tests/integration/components/rental-test.js
+[DATA] tests/integration/components/rental/detailed-test.js
+[DATA] tests/integration/components/rental/image-test.js
+[DATA] tests/integration/components/rentals-test.js
+[DATA] tests/integration/components/share-button-test.js
+[DATA] tests/test-helper.js
+[DATA] tests/unit/models/rental-test.js
+[SUCCESS] Analyzing project dependency graph"
+`;
+
+exports[`validation-test ember@4.4 LTS > migrate 1`] = `
+"import Component from '@glimmer/component';
+import ENV from 'super-rentals/config/environment';
+
+const MAPBOX_API = 'https://api.mapbox.com/styles/v1/mapbox/streets-v11/static';
+
+export default class MapComponent extends Component {
+  get src() {
+    // @ts-expect-error @rehearsal TODO TS2339: Property 'lng' does not exist on type 'Readonly<EmptyObject>'.
+    let { lng, lat, width, height, zoom } = this.args;
+
+    let coordinates = \`\${lng},\${lat},\${zoom}\`;
+    let dimensions = \`\${width}x\${height}\`;
+    let accessToken = \`access_token=\${this.token}\`;
+
+    return \`\${MAPBOX_API}/\${coordinates}/\${dimensions}@2x?\${accessToken}\`;
+  }
+
+  get token() {
+    return encodeURIComponent(ENV.MAPBOX_ACCESS_TOKEN);
+  }
+}
+"
+`;
+
+exports[`validation-test ember@4.4 LTS > migrate 2`] = `
+"import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+const TWEET_INTENT = 'https://twitter.com/intent/tweet';
+
+export default class ShareButtonComponent extends Component {
+  // @ts-expect-error @rehearsal TODO TS2564: Property 'router' has no initializer and is not definitely assigned in the constructor.
+  @service router: { currentURL: string | URL };
+  // @ts-expect-error @rehearsal TODO TS2564: Property 'locale' has no initializer and is not definitely assigned in the constructor.
+  @service locale: { current: () => string };
+
+  get currentURL() {
+    return new URL(this.router.currentURL, window.location.origin);
+  }
+
+  get shareURL() {
+    let url = new URL(TWEET_INTENT);
+
+    // @ts-expect-error @rehearsal TODO TS2345: Argument of type 'URL' is not assignable to parameter of type 'string'. Consider verifying both types, using type assertion: '( this.currentURL as string)', or using type guard: 'if ( this.currentURL instanceof string) { ... }'.
+    url.searchParams.set('url', this.currentURL);
+
+    // @ts-expect-error @rehearsal TODO TS2339: Property 'text' does not exist on type 'Readonly<EmptyObject>'.
+    if (this.args.text) {
+      // @ts-expect-error @rehearsal TODO TS2339: Property 'text' does not exist on type 'Readonly<EmptyObject>'.
+      url.searchParams.set('text', this.args.text);
+    }
+
+    // @ts-expect-error @rehearsal TODO TS2339: Property 'hashtags' does not exist on type 'Readonly<EmptyObject>'.
+    if (this.args.hashtags) {
+      // @ts-expect-error @rehearsal TODO TS2339: Property 'hashtags' does not exist on type 'Readonly<EmptyObject>'.
+      url.searchParams.set('hashtags', this.args.hashtags);
+    }
+
+    // @ts-expect-error @rehearsal TODO TS2339: Property 'via' does not exist on type 'Readonly<EmptyObject>'.
+    if (this.args.via) {
+      // @ts-expect-error @rehearsal TODO TS2339: Property 'via' does not exist on type 'Readonly<EmptyObject>'.
+      url.searchParams.set('via', this.args.via);
+    }
+
+    url.searchParams.set('locale', this.locale.current());
+
+    return url;
+  }
+}
+"
+`;
+
+exports[`validation-test ember@4.4 LTS > migrate 3`] = `
 "import Model, { attr } from '@ember-data/model';
 
 const COMMUNITY_CATEGORIES = ['Condo', 'Townhouse', 'Apartment'];

--- a/test/__snapshots__/move.test.js.snap
+++ b/test/__snapshots__/move.test.js.snap
@@ -13,7 +13,7 @@ Options:
 `;
 
 exports[`validation-test: rehearsal move > 'simple': move [ '--source', 'index.js' ] 1`] = `
-"[32minfo[39m:    @rehearsal/move 2.0.0-beta
+"[32minfo[39m:    @rehearsal/move VERSION
 [STARTED] Initialize
 [SUCCESS] Initialize
 [STARTED] Executing git mv
@@ -25,7 +25,7 @@ exports[`validation-test: rehearsal move > 'simple': move [ '--source', 'index.j
 `;
 
 exports[`validation-test: rehearsal move > 'workspace': move [ '--childPackage', 'packages/blorp' ] 1`] = `
-"[32minfo[39m:    @rehearsal/move 2.0.0-beta
+"[32minfo[39m:    @rehearsal/move VERSION
 [STARTED] Initialize
 [SUCCESS] Initialize
 [STARTED] Analyzing project dependency graph

--- a/test/ember.test.js
+++ b/test/ember.test.js
@@ -27,6 +27,7 @@ describe('validation-test ember@3.28 LTS', () => {
     expect(readFile('app/components/map.ts')).toMatchSnapshot();
     expect(readFile('app/components/share-button.ts')).toMatchSnapshot();
     expect(readFile('app/models/rental.ts')).toMatchSnapshot();
+    expect(readFile('app/components/HelloWorld.gts')).toMatchSnapshot();
 
     project.dispose();
   });
@@ -58,6 +59,7 @@ describe('validation-test ember@4.4 LTS', () => {
     expect(readFile('app/components/map.ts')).toMatchSnapshot();
     expect(readFile('app/components/share-button.ts')).toMatchSnapshot();
     expect(readFile('app/models/rental.ts')).toMatchSnapshot();
+    expect(readFile('app/components/HelloWorld.gts')).toMatchSnapshot();
 
     project.dispose();
   });

--- a/test/ember.test.js
+++ b/test/ember.test.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+import { describe, expect, test, beforeEach, beforeAll } from 'vitest';
+import { join } from 'path';
+import { Project } from 'fixturify-project';
+import { commandSync } from 'execa';
+import { runCommandFactory, setupEmberProject, resolveCLIBin } from './test-helpers';
+import { existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { afterEach } from 'vitest';
+
+const superRentalsHashes = {
+  //   'ember-source@~4.5': '9c510c46bff431f146bbbd9820a05a8e57c9b2eb',
+  'ember-source@~3.27': 'f1a8cf65bcdd8da7b96bf129a0d618ef94e75601'
+};
+
+describe('validation-test ember@3.28 LTS', () => {
+  let run;
+  let pathToSuperRentals;
+  let project;
+
+  beforeAll(() => {
+    const tmpDir = new URL('../tmp/', import.meta.url);
+
+    if (!existsSync(tmpDir)) {
+      commandSync(`mkdir -p ${fileURLToPath(tmpDir)}`, { shell: true });
+    }
+
+    const hash = superRentalsHashes['ember-source@~3.27'];
+    pathToSuperRentals = join(fileURLToPath(tmpDir), `super-rentals-${hash}`);
+
+    if (!existsSync(pathToSuperRentals)) {
+      // Download archive
+      const archiveURL = `https://github.com/ember-learn/super-rentals/archive/${hash}.zip`;
+
+      commandSync(`wget ${archiveURL}`, {
+        cwd: tmpDir,
+        shell: true
+      });
+      commandSync(`unzip ${hash}.zip`, { cwd: tmpDir, shell: true });
+      commandSync(`rm ${hash}.zip`, { cwd: tmpDir, shell: true });
+      commandSync('pnpm install', { cwd: pathToSuperRentals });
+    }
+  });
+
+  beforeEach(async () => {
+    project = Project.fromDir(pathToSuperRentals, { linkDeps: true, linkDevDeps: true });
+
+    project.addDevDependency('ember-source', '~3.28.0');
+    project.addDevDependency('ember-cli', '~3.28.0');
+
+    project.mergeFiles({
+      app: {
+        components: {
+          'share-button.js': `import { inject as service } from '@ember/service';
+    import Component from '@glimmer/component';
+
+    const TWEET_INTENT = 'https://twitter.com/intent/tweet';
+
+    export default class ShareButtonComponent extends Component {
+      @service router;
+      @service locale;
+
+      get currentURL() {
+        return new URL(this.router.currentURL, window.location.origin);
+      }
+
+      get shareURL() {
+        let url = new URL(TWEET_INTENT);
+
+        url.searchParams.set('url', this.currentURL);
+
+        if (this.args.text) {
+          url.searchParams.set('text', this.args.text);
+        }
+
+        if (this.args.hashtags) {
+          url.searchParams.set('hashtags', this.args.hashtags);
+        }
+
+        if (this.args.via) {
+          url.searchParams.set('via', this.args.via);
+        }
+
+        url.searchParams.set('locale', this.locale.current());
+
+        return url;
+      }
+    }`
+        },
+        services: {
+          'locale.js': `
+            import Service from '@ember/service';
+
+            export default class LocaleService extends Service {
+                current() {
+                    return 'en-US';
+                }
+            }
+          `
+        }
+      }
+    });
+
+    // Setup project with dependencies to use rehearsal e.g. typescript, eslint, prettier, @glint/*
+    await setupEmberProject(project);
+
+    const bin = resolveCLIBin(project);
+    // Set up command for tests
+    run = runCommandFactory(bin, { cwd: project.baseDir });
+  });
+
+  afterEach(() => {
+    project.dispose();
+  });
+
+  test('graph', () => {
+    const results = run(['graph']);
+
+    expect(results.exitCode).toBe(0);
+    expect(results.stdout, 'should show ordering between locale service and share-button')
+      .toContain(`[DATA] app/services/locale.js
+[DATA] app/components/share-button.js`);
+
+    expect(results.stdout).toMatchSnapshot();
+  });
+
+  test('migrate', () => {
+    const results = run(['migrate', '--ci']);
+
+    expect(results.exitCode).toBe(0);
+    expect(results.stdout).toContain('[STARTED] Convert JS files to TS');
+    expect(results.stdout).toContain('[SUCCESS] Migration Complete');
+  });
+});

--- a/test/ember.test.js
+++ b/test/ember.test.js
@@ -1,125 +1,9 @@
-#!/usr/bin/env node
-
-import { describe, expect, test, beforeEach, beforeAll } from 'vitest';
-import { join } from 'path';
-import { Project } from 'fixturify-project';
-import { commandSync } from 'execa';
-import { runCommandFactory, setupEmberProject, resolveCLIBin } from './test-helpers';
-import { existsSync, readFileSync } from 'fs';
-import { fileURLToPath } from 'url';
-import { afterEach } from 'vitest';
-
-const superRentalsHashes = {
-  //   'ember-source@~4.5': '9c510c46bff431f146bbbd9820a05a8e57c9b2eb',
-  'ember-source@~3.27': 'f1a8cf65bcdd8da7b96bf129a0d618ef94e75601'
-};
+import { describe, expect, test } from 'vitest';
+import { setupProjectRunner } from './test-helpers';
 
 describe('validation-test ember@3.28 LTS', () => {
-  let run;
-  let pathToSuperRentals;
-  let project;
-  let readFile;
-
-  beforeAll(() => {
-    const tmpDir = new URL('../tmp/', import.meta.url);
-
-    if (!existsSync(tmpDir)) {
-      commandSync(`mkdir -p ${fileURLToPath(tmpDir)}`, { shell: true });
-    }
-
-    const hash = superRentalsHashes['ember-source@~3.27'];
-    pathToSuperRentals = join(fileURLToPath(tmpDir), `super-rentals-${hash}`);
-
-    if (!existsSync(pathToSuperRentals)) {
-      // Download archive
-      const archiveURL = `https://github.com/ember-learn/super-rentals/archive/${hash}.zip`;
-
-      commandSync(`wget ${archiveURL}`, {
-        cwd: tmpDir,
-        shell: true
-      });
-      commandSync(`unzip ${hash}.zip`, { cwd: tmpDir, shell: true });
-      commandSync(`rm ${hash}.zip`, { cwd: tmpDir, shell: true });
-      commandSync('pnpm install', { cwd: pathToSuperRentals });
-    }
-  });
-
-  beforeEach(async () => {
-    project = Project.fromDir(pathToSuperRentals, { linkDeps: true, linkDevDeps: true });
-
-    project.addDevDependency('ember-source', '~3.28.0');
-    project.addDevDependency('ember-cli', '~3.28.0');
-
-    project.mergeFiles({
-      app: {
-        components: {
-          'share-button.js': `import { inject as service } from '@ember/service';
-    import Component from '@glimmer/component';
-
-    const TWEET_INTENT = 'https://twitter.com/intent/tweet';
-
-    export default class ShareButtonComponent extends Component {
-      @service router;
-      @service locale;
-
-      get currentURL() {
-        return new URL(this.router.currentURL, window.location.origin);
-      }
-
-      get shareURL() {
-        let url = new URL(TWEET_INTENT);
-
-        url.searchParams.set('url', this.currentURL);
-
-        if (this.args.text) {
-          url.searchParams.set('text', this.args.text);
-        }
-
-        if (this.args.hashtags) {
-          url.searchParams.set('hashtags', this.args.hashtags);
-        }
-
-        if (this.args.via) {
-          url.searchParams.set('via', this.args.via);
-        }
-
-        url.searchParams.set('locale', this.locale.current());
-
-        return url;
-      }
-    }`
-        },
-        services: {
-          'locale.js': `
-            import Service from '@ember/service';
-
-            export default class LocaleService extends Service {
-                current() {
-                    return 'en-US';
-                }
-            }
-          `
-        }
-      }
-    });
-
-    // Setup project with dependencies to use rehearsal e.g. typescript, eslint, prettier, @glint/*
-    await setupEmberProject(project);
-
-    const bin = resolveCLIBin(project);
-    // Set up command for tests
-    run = runCommandFactory(bin, { cwd: project.baseDir });
-
-    readFile = (filePath) => {
-      return readFileSync(join(project.baseDir, filePath), 'utf-8');
-    };
-  });
-
-  afterEach(() => {
-    project.dispose();
-  });
-
-  test('graph', () => {
+  test('graph', async () => {
+    const { run, project } = await setupProjectRunner('ember-app-3.28');
     const results = run(['graph']);
 
     expect(results.exitCode).toBe(0);
@@ -128,9 +12,12 @@ describe('validation-test ember@3.28 LTS', () => {
 [DATA] app/components/share-button.js`);
 
     expect(results.stdout).toMatchSnapshot();
+
+    project.dispose();
   });
 
-  test('migrate', () => {
+  test('migrate', async () => {
+    const { run, project, readFile } = await setupProjectRunner('ember-app-3.28');
     const results = run(['migrate', '--ci']);
 
     expect(results.exitCode).toBe(0);
@@ -140,5 +27,38 @@ describe('validation-test ember@3.28 LTS', () => {
     expect(readFile('app/components/map.ts')).toMatchSnapshot();
     expect(readFile('app/components/share-button.ts')).toMatchSnapshot();
     expect(readFile('app/models/rental.ts')).toMatchSnapshot();
+
+    project.dispose();
+  });
+});
+
+describe('validation-test ember@4.4 LTS', () => {
+  test('graph', async () => {
+    const { run, project } = await setupProjectRunner('ember-app-4.4');
+    const results = run(['graph']);
+
+    expect(results.exitCode).toBe(0);
+    expect(results.stdout, 'should show ordering between locale service and share-button')
+      .toContain(`[DATA] app/services/locale.js
+[DATA] app/components/share-button.js`);
+
+    expect(results.stdout).toMatchSnapshot();
+
+    project.dispose();
+  });
+
+  test('migrate', async () => {
+    const { run, project, readFile } = await setupProjectRunner('ember-app-4.4');
+    const results = run(['migrate', '--ci']);
+
+    expect(results.exitCode).toBe(0);
+    expect(results.stdout).toContain('[STARTED] Convert JS files to TS');
+    expect(results.stdout).toContain('[SUCCESS] Migration Complete');
+
+    expect(readFile('app/components/map.ts')).toMatchSnapshot();
+    expect(readFile('app/components/share-button.ts')).toMatchSnapshot();
+    expect(readFile('app/models/rental.ts')).toMatchSnapshot();
+
+    project.dispose();
   });
 });

--- a/test/ember.test.js
+++ b/test/ember.test.js
@@ -5,7 +5,7 @@ import { join } from 'path';
 import { Project } from 'fixturify-project';
 import { commandSync } from 'execa';
 import { runCommandFactory, setupEmberProject, resolveCLIBin } from './test-helpers';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { afterEach } from 'vitest';
 
@@ -18,6 +18,7 @@ describe('validation-test ember@3.28 LTS', () => {
   let run;
   let pathToSuperRentals;
   let project;
+  let readFile;
 
   beforeAll(() => {
     const tmpDir = new URL('../tmp/', import.meta.url);
@@ -108,6 +109,10 @@ describe('validation-test ember@3.28 LTS', () => {
     const bin = resolveCLIBin(project);
     // Set up command for tests
     run = runCommandFactory(bin, { cwd: project.baseDir });
+
+    readFile = (filePath) => {
+      return readFileSync(join(project.baseDir, filePath), 'utf-8');
+    };
   });
 
   afterEach(() => {
@@ -131,5 +136,9 @@ describe('validation-test ember@3.28 LTS', () => {
     expect(results.exitCode).toBe(0);
     expect(results.stdout).toContain('[STARTED] Convert JS files to TS');
     expect(results.stdout).toContain('[SUCCESS] Migration Complete');
+
+    expect(readFile('app/components/map.ts')).toMatchSnapshot();
+    expect(readFile('app/components/share-button.ts')).toMatchSnapshot();
+    expect(readFile('app/models/rental.ts')).toMatchSnapshot();
   });
 });

--- a/test/ember.test.js
+++ b/test/ember.test.js
@@ -1,9 +1,19 @@
-import { describe, expect, test } from 'vitest';
-import { setupProjectRunner } from './test-helpers';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { getProjectFixture, setupProjectRunner } from './test-helpers';
 
 describe('validation-test ember@3.28 LTS', () => {
-  test('graph', async () => {
-    const { run, project } = await setupProjectRunner('ember-app-3.28');
+  let project;
+
+  beforeEach(async () => {
+    project = await getProjectFixture('ember-app-3.28');
+  });
+
+  afterEach(() => {
+    project.dispose();
+  });
+
+  test('graph', () => {
+    const { run } = setupProjectRunner(project);
     const results = run(['graph']);
 
     expect(results.exitCode).toBe(0);
@@ -16,8 +26,8 @@ describe('validation-test ember@3.28 LTS', () => {
     project.dispose();
   });
 
-  test('migrate', async () => {
-    const { run, project, readFile } = await setupProjectRunner('ember-app-3.28');
+  test('migrate', () => {
+    const { run, readFile } = setupProjectRunner(project);
     const results = run(['migrate', '--ci']);
 
     expect(results.exitCode).toBe(0);
@@ -28,14 +38,22 @@ describe('validation-test ember@3.28 LTS', () => {
     expect(readFile('app/components/share-button.ts')).toMatchSnapshot();
     expect(readFile('app/models/rental.ts')).toMatchSnapshot();
     expect(readFile('app/components/HelloWorld.gts')).toMatchSnapshot();
-
-    project.dispose();
   });
 });
 
 describe('validation-test ember@4.4 LTS', () => {
-  test('graph', async () => {
-    const { run, project } = await setupProjectRunner('ember-app-4.4');
+  let project;
+
+  beforeEach(async () => {
+    project = await getProjectFixture('ember-app-4.4');
+  });
+
+  afterEach(() => {
+    project.dispose();
+  });
+
+  test('graph', () => {
+    const { run } = setupProjectRunner(project);
     const results = run(['graph']);
 
     expect(results.exitCode).toBe(0);
@@ -48,8 +66,8 @@ describe('validation-test ember@4.4 LTS', () => {
     project.dispose();
   });
 
-  test('migrate', async () => {
-    const { run, project, readFile } = await setupProjectRunner('ember-app-4.4');
+  test('migrate', () => {
+    const { run, readFile } = setupProjectRunner(project);
     const results = run(['migrate', '--ci']);
 
     expect(results.exitCode).toBe(0);
@@ -60,7 +78,5 @@ describe('validation-test ember@4.4 LTS', () => {
     expect(readFile('app/components/share-button.ts')).toMatchSnapshot();
     expect(readFile('app/models/rental.ts')).toMatchSnapshot();
     expect(readFile('app/components/HelloWorld.gts')).toMatchSnapshot();
-
-    project.dispose();
   });
 });

--- a/test/ember.test.js
+++ b/test/ember.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from 'vitest';
+import { describe, expect, test, afterEach, beforeEach } from 'vitest';
 import { getProjectFixture, setupProjectRunner } from './test-helpers';
 
 describe('validation-test ember@3.28 LTS', () => {

--- a/test/graph.test.js
+++ b/test/graph.test.js
@@ -1,14 +1,14 @@
 import { describe, expect, test, afterEach, beforeEach } from 'vitest';
-import { setupProjectRunner } from './test-helpers';
+import { getProjectFixture, setupProjectRunner } from './test-helpers';
 
 describe('validation-test: rehearsal graph', () => {
   let run;
   let project;
 
   beforeEach(async () => {
-    let runner = await setupProjectRunner('simple');
+    project = await getProjectFixture('simple');
+    let runner = setupProjectRunner(project);
     run = runner.run;
-    project = runner.project;
   });
 
   afterEach(async () => {

--- a/test/migrate.test.js
+++ b/test/migrate.test.js
@@ -1,14 +1,14 @@
 import { describe, expect, test, afterEach, beforeEach } from 'vitest';
-import { setupProjectRunner } from './test-helpers';
+import { getProjectFixture, setupProjectRunner } from './test-helpers';
 
 describe('validation-test: rehearsal migrate', () => {
   let run;
   let project;
 
   beforeEach(async () => {
-    let runner = await setupProjectRunner('simple');
+    project = await getProjectFixture('simple');
+    let runner = setupProjectRunner(project);
     run = runner.run;
-    project = runner.project;
   });
 
   afterEach(async () => {

--- a/test/move.test.js
+++ b/test/move.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { setupProjectRunner } from './test-helpers';
+import { getProjectFixture, setupProjectRunner } from './test-helpers';
 
 describe('validation-test: rehearsal move', async () => {
   const variants = [
@@ -10,7 +10,8 @@ describe('validation-test: rehearsal move', async () => {
   ];
 
   test.each(variants)('$variant: move $args', async ({ variant, args }) => {
-    const { run, project } = await setupProjectRunner(variant);
+    const project = await getProjectFixture(variant);
+    const { run } = setupProjectRunner(project);
     const results = run(['move', ...args]);
     expect(results.exitCode).toBe(0);
     expect(results.stdout).toMatchSnapshot();

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -144,6 +144,17 @@ export function resolveCLIBin(project) {
   return bin;
 }
 
+// Reference https://ihateregex.io/expr/semver/
+const REGEX_REHEARSAL_PACKAGE_VERSION =
+  /(?!\@rehearsal\/.*)(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/;
+
+function replaceVersion(output) {
+  if (output && output.search(REGEX_REHEARSAL_PACKAGE_VERSION) > -1) {
+    output = output.replace(REGEX_REHEARSAL_PACKAGE_VERSION, 'VERSION');
+  }
+  return output;
+}
+
 export function runCommandFactory(rehearsalCLIBin, factoryOptions) {
   return (args, options) => {
     const command = `node ${rehearsalCLIBin} ${args.join(' ')}`;
@@ -154,6 +165,8 @@ export function runCommandFactory(rehearsalCLIBin, factoryOptions) {
 
     DEBUG_CALLBACK('Command: %s', command);
     DEBUG_CALLBACK(results.stdout);
+
+    results.stdout = replaceVersion(results.stdout);
 
     return results;
   };

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -417,13 +417,11 @@ export async function getProjectFixture(variant) {
   throw new Error(`Invalid project fixture variant: ${variant}`);
 }
 
-export async function setupProjectRunner(variant) {
-  const project = await getProjectFixture(variant);
-
+export function setupProjectRunner(project) {
   const run = runCommandFactory(resolveCLIBin(project), { cwd: project.baseDir });
 
   const readFile = (filePath) => {
     return readFileSync(join(project.baseDir, filePath), 'utf-8');
   };
-  return { run, project, readFile };
+  return { run, readFile };
 }

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -353,6 +353,25 @@ function patchEmberAppWithService(project) {
   });
 }
 
+function patchEmberAppWithGjsComponent(project) {
+  project.mergeFiles({
+    app: {
+      components: {
+        'HelloWorld.gjs': `import Component from '@glimmer/component';
+
+export default class Hello extends Component {
+  name = 'world';
+
+  <template>
+    <span>Hello, I am {{this.name}} and I am {{@age}} years old!</span>
+  </template>
+}
+`
+      }
+    }
+  });
+}
+
 function getEmberApp3_28() {
   const pathToFixture = setupSuperRentals('ember-source@~3.27');
   const project = Project.fromDir(pathToFixture, { linkDeps: false, linkDevDeps: false });
@@ -383,12 +402,14 @@ export async function getProjectFixture(variant) {
   if (variant == 'ember-app-3.28') {
     const project = getEmberApp3_28();
     patchEmberAppWithService(project);
+    patchEmberAppWithGjsComponent(project);
     await setupEmberProject(project);
     return project;
   }
   if (variant == 'ember-app-4.4') {
     const project = getEmberApp4_4();
     patchEmberAppWithService(project);
+    patchEmberAppWithGjsComponent(project);
     await setupEmberProject(project);
     return project;
   }

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -1,8 +1,11 @@
+import { readFileSync, writeFileSync } from 'node:fs';
 import Module from 'node:module';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { commandSync } from 'execa';
 import { Project } from 'fixturify-project';
+import JSON5 from 'json5';
+
 import {
   readPackageJson,
   writePackageJson,
@@ -13,12 +16,80 @@ import {
 const PROJECT_ROOT_URL = new URL('../', import.meta.url);
 const PROJECT_ROOT_DIR = fileURLToPath(PROJECT_ROOT_URL);
 
-/**
- * Add the necessary devDependencies for a project fixture to run rehearasl.
- * @param {Project} project
- * @returns
- */
-export async function setupProject(project) {
+function readTSConfig(baseDir) {
+  return JSON5.parse(readFileSync(join(baseDir, './tsconfig.json'), 'utf-8'));
+}
+
+function writeTSConfig(baseDir, data) {
+  writeFileSync(join(baseDir, './tsconfig.json'), JSON5.stringify(data, { space: 2, quote: '"' }));
+}
+
+function setupProjectWithRehearsalBinaries(project) {
+  let packageJson = readPackageJson(project.baseDir);
+
+  packageJson['packageManager'] = 'pnpm@7.12.1';
+  // Get packageJson entries for @rehearsal packages from root package.json
+  const packagePaths = findRehearsalPackages(readPackageJson(PROJECT_ROOT_DIR));
+
+  // Add root relative paths to tarballs in package.json similar to this project
+  packageJson = updatePackageJson(packageJson, packagePaths);
+
+  writePackageJson(project.baseDir, packageJson);
+
+  // Copy binaries from PROJECT_ROOT_DIR to fixture directory
+  for (const [, packagePath] of packagePaths) {
+    const tarballPath = join(PROJECT_ROOT_DIR, fileURLToPath(packagePath));
+    const copyResults = commandSync(`cp ${tarballPath} ${project.baseDir}`, {
+      cwd: PROJECT_ROOT_DIR
+    });
+    if (copyResults.exitCode !== 0) {
+      throw new Error(
+        `Copying ${tarballPath} to project fixture directory failed.\n${results.stderr}`
+      );
+    }
+  }
+
+  const results = commandSync('pnpm install', { cwd: project.baseDir });
+
+  if (results.exitCode !== 0) {
+    throw new Error(`Install failed; unable to setup project fixture.\n${results.stderr}`);
+  }
+}
+
+export async function setupEmberProject(project) {
+  addRehearsalDependencies(project);
+  project.addDevDependency('@types/node', '18.15.12');
+  project.addDevDependency('@glint/core', '1.0.0-beta.4');
+  project.addDevDependency('@glint/template', '1.0.0-beta.4');
+  project.addDevDependency('@glint/environment-ember-loose', '1.0.0-beta.4');
+  project.addDevDependency('@glint/environment-ember-template-imports', '1.0.0-beta.4');
+  project.addDevDependency('ember-cli-typescript', '5.2.1');
+  project.addDevDependency('ember-template-imports', '3.4.2');
+
+  await project.write();
+
+  const opts = { cwd: project.baseDir, shell: true };
+  // We have to use yarn for this step because ember cli doesn't know about pnpm usage.
+  commandSync('yarn install', opts);
+  commandSync('yarn ember generate ember-cli-typescript', opts);
+
+  // Append glint configuration entry to tsconfig.json
+
+  const tsConfig = readTSConfig(project.baseDir);
+
+  tsConfig['glint'] = {
+    environment: ['ember-loose', 'ember-template-imports'],
+    checkStandaloneTemplates: true
+  };
+
+  writeTSConfig(project.baseDir, tsConfig);
+
+  setupProjectWithRehearsalBinaries(project);
+
+  return project;
+}
+
+function addRehearsalDependencies(project) {
   // Typescript
   project.addDevDependency('typescript', '5.0.4');
 
@@ -31,39 +102,19 @@ export async function setupProject(project) {
   project.addDevDependency('prettier', '2.8.7');
   project.addDevDependency('eslint-config-prettier', '8.8.0');
   project.addDevDependency('eslint-plugin-prettier', '4.2.1');
+}
 
-  // Get packageJson entries for @rehearsal packages from root package.json
-  // transform paths to be absolute paths to the tarball files.
-  let packagePaths = findRehearsalPackages(readPackageJson(PROJECT_ROOT_DIR)).map(
-    ([packageName, packagePath]) => {
-      const pathToTarball = join(PROJECT_ROOT_DIR, fileURLToPath(packagePath));
-      return [packageName, pathToTarball];
-    }
-  );
+/**
+ * Add the necessary devDependencies for a project fixture to run rehearasl.
+ * @param {Project} project
+ * @returns
+ */
+export async function setupProject(project) {
+  addRehearsalDependencies(project);
 
   await project.write();
 
-  const packageJson = readPackageJson(project.baseDir);
-
-  packageJson['packageManager'] = 'pnpm@7.12.1';
-
-  updatePackageJson(packageJson, packagePaths);
-
-  writePackageJson(project.baseDir, packageJson);
-
-  // Copy binaries to root of project fixture
-  for (const [, pathToTarball] of packagePaths) {
-    commandSync(`cp ${pathToTarball} ./`, { cwd: project.baseDir });
-  }
-
-  let results;
-
-  // Install dependencies
-  results = commandSync('pnpm install', { cwd: project.baseDir });
-
-  if (results.exitCode !== 0) {
-    throw new Error(`Install failed; unable to setup project fixture.\n${results.stderr}`);
-  }
+  setupProjectWithRehearsalBinaries(project);
 
   return project;
 }

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -1,10 +1,11 @@
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, existsSync, writeFileSync } from 'node:fs';
 import Module from 'node:module';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { commandSync } from 'execa';
 import { Project } from 'fixturify-project';
 import JSON5 from 'json5';
+import debug from 'debug';
 
 import {
   readPackageJson,
@@ -13,8 +14,15 @@ import {
   updatePackageJson
 } from '../utils';
 
+const DEBUG_CALLBACK = debug('rehearsal:smoke-test');
+
 const PROJECT_ROOT_URL = new URL('../', import.meta.url);
 const PROJECT_ROOT_DIR = fileURLToPath(PROJECT_ROOT_URL);
+
+const superRentalsHashes = {
+  'ember-source@~4.5': '9c510c46bff431f146bbbd9820a05a8e57c9b2eb',
+  'ember-source@~3.27': 'f1a8cf65bcdd8da7b96bf129a0d618ef94e75601'
+};
 
 function readTSConfig(baseDir) {
   return JSON5.parse(readFileSync(join(baseDir, './tsconfig.json'), 'utf-8'));
@@ -59,19 +67,24 @@ function setupProjectWithRehearsalBinaries(project) {
 export async function setupEmberProject(project) {
   addRehearsalDependencies(project);
   project.addDevDependency('@types/node', '18.15.12');
-  project.addDevDependency('@glint/core', '1.0.0-beta.4');
-  project.addDevDependency('@glint/template', '1.0.0-beta.4');
-  project.addDevDependency('@glint/environment-ember-loose', '1.0.0-beta.4');
-  project.addDevDependency('@glint/environment-ember-template-imports', '1.0.0-beta.4');
+  project.addDevDependency('@glint/core', '^1.0.0');
+  project.addDevDependency('@glint/template', '^1.0.0');
+  project.addDevDependency('@glint/environment-ember-loose', '^1.0.0');
+  project.addDevDependency('@glint/environment-ember-template-imports', '^1.0.0');
   project.addDevDependency('ember-cli-typescript', '5.2.1');
   project.addDevDependency('ember-template-imports', '3.4.2');
 
-  await project.write();
+  // Required from @glint/core>=1.0.0
+  project.addDevDependency('@glimmer/component', '^1.1.2');
+  project.addDevDependency('ember-modifier', '^3.2.7');
+  project.addDevDependency('@types/ember__component', '^4.0.8');
 
+  await project.write();
+  DEBUG_CALLBACK('Project Directory %s', project.baseDir);
   const opts = { cwd: project.baseDir, shell: true };
   // We have to use yarn for this step because ember cli doesn't know about pnpm usage.
   commandSync('yarn install', opts);
-  commandSync('yarn ember generate ember-cli-typescript', opts);
+  commandSync('yarn ember install ember-cli-typescript', opts);
 
   // Append glint configuration entry to tsconfig.json
 
@@ -133,10 +146,16 @@ export function resolveCLIBin(project) {
 
 export function runCommandFactory(rehearsalCLIBin, factoryOptions) {
   return (args, options) => {
-    return commandSync(`node ${rehearsalCLIBin} ${args.join(' ')}`, {
+    const command = `node ${rehearsalCLIBin} ${args.join(' ')}`;
+    const results = commandSync(command, {
       ...factoryOptions,
       ...options
     });
+
+    DEBUG_CALLBACK('Command: %s', command);
+    DEBUG_CALLBACK(results.stdout);
+
+    return results;
   };
 }
 
@@ -248,20 +267,142 @@ export function getWorkspaceProjectFixture() {
   return project;
 }
 
-export function getProjectFixture(variant) {
+function setupSuperRentals(key) {
+  const tmpDir = new URL('../tmp/', import.meta.url);
+
+  if (!existsSync(tmpDir)) {
+    commandSync(`mkdir -p ${fileURLToPath(tmpDir)}`, { shell: true });
+  }
+
+  if (!superRentalsHashes[key]) {
+    throw new Error('Invalid key for super rentals');
+  }
+
+  const hash = superRentalsHashes[key];
+  const pathToSuperRentals = join(fileURLToPath(tmpDir), `super-rentals-${hash}`);
+
+  if (!existsSync(pathToSuperRentals)) {
+    // Download archive
+    const archiveURL = `https://github.com/ember-learn/super-rentals/archive/${hash}.zip`;
+
+    commandSync(`wget ${archiveURL}`, {
+      cwd: tmpDir,
+      shell: true
+    });
+    commandSync(`unzip ${hash}.zip`, { cwd: tmpDir, shell: true });
+    commandSync(`rm ${hash}.zip`, { cwd: tmpDir, shell: true });
+    commandSync('yarn install', { cwd: pathToSuperRentals });
+  }
+
+  return pathToSuperRentals;
+}
+
+function patchEmberAppWithService(project) {
+  // Add service and update a component to use that service.
+  project.mergeFiles({
+    app: {
+      components: {
+        'share-button.js': `import { inject as service } from '@ember/service';
+    import Component from '@glimmer/component';
+
+    const TWEET_INTENT = 'https://twitter.com/intent/tweet';
+
+    export default class ShareButtonComponent extends Component {
+      @service router;
+      @service locale;
+
+      get currentURL() {
+        return new URL(this.router.currentURL, window.location.origin);
+      }
+
+      get shareURL() {
+        let url = new URL(TWEET_INTENT);
+
+        url.searchParams.set('url', this.currentURL);
+
+        if (this.args.text) {
+          url.searchParams.set('text', this.args.text);
+        }
+
+        if (this.args.hashtags) {
+          url.searchParams.set('hashtags', this.args.hashtags);
+        }
+
+        if (this.args.via) {
+          url.searchParams.set('via', this.args.via);
+        }
+
+        url.searchParams.set('locale', this.locale.current());
+
+        return url;
+      }
+    }`
+      },
+      services: {
+        'locale.js': `
+            import Service from '@ember/service';
+
+            export default class LocaleService extends Service {
+                current() {
+                    return 'en-US';
+                }
+            }
+          `
+      }
+    }
+  });
+}
+
+function getEmberApp3_28() {
+  const pathToFixture = setupSuperRentals('ember-source@~3.27');
+  const project = Project.fromDir(pathToFixture, { linkDeps: false, linkDevDeps: false });
+  project.addDevDependency('ember-source', '~3.28.0');
+  project.addDevDependency('ember-cli', '~3.28.0');
+  return project;
+}
+
+function getEmberApp4_4() {
+  const pathToFixture = setupSuperRentals('ember-source@~4.5');
+  const project = Project.fromDir(pathToFixture, { linkDeps: false, linkDevDeps: false });
+  project.addDevDependency('ember-source', '~4.4.0');
+  project.addDevDependency('ember-cli', '~4.4.0');
+  return project;
+}
+
+export async function getProjectFixture(variant) {
   if (variant == 'simple') {
-    return getSimpleProjectFixture();
+    const project = getSimpleProjectFixture();
+    await setupProject(project);
+    return project;
   }
   if (variant == 'workspace') {
-    return getWorkspaceProjectFixture();
+    const project = getWorkspaceProjectFixture();
+    await setupProject(project);
+    return project;
+  }
+  if (variant == 'ember-app-3.28') {
+    const project = getEmberApp3_28();
+    patchEmberAppWithService(project);
+    await setupEmberProject(project);
+    return project;
+  }
+  if (variant == 'ember-app-4.4') {
+    const project = getEmberApp4_4();
+    patchEmberAppWithService(project);
+    await setupEmberProject(project);
+    return project;
   }
 
   throw new Error(`Invalid project fixture variant: ${variant}`);
 }
 
 export async function setupProjectRunner(variant) {
-  const project = getProjectFixture(variant);
-  await setupProject(project);
+  const project = await getProjectFixture(variant);
+
   const run = runCommandFactory(resolveCLIBin(project), { cwd: project.baseDir });
-  return { run, project };
+
+  const readFile = (filePath) => {
+    return readFileSync(join(project.baseDir, filePath), 'utf-8');
+  };
+  return { run, project, readFile };
 }

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     testTimeout: 100_000,
     hookTimeout: 50_000,
-    watchExclude: ['package.json', '**/fixtures/**'],
-    threads: false,
-  },
+    watchExclude: ['package.json', '**/fixtures/**', 'tmp'],
+    threads: false
+  }
 });


### PR DESCRIPTION
This PR depends on #14 
This rebases off of the move feature branch. Related to #11 

### Summary
- Downloads super-rentals to a tmp dir at a specific version.
- Creates a fixture from [ember-learn/super-rentals](https://github.com/ember-learn/super-rentals/commit/f1a8cf65bcdd8da7b96bf129a0d618ef94e75601) 
- Uses version where source code is close to 3.28 or 4.4 and patches to use`ember-source` and `ember-cli`  at LTS.
- Adds test-helpers for bootstrapping an ember project `@glint/*` dependencies to run rehearsal migrate.
- Validates service dependency in graph order.
- Strips version for commands from output `@rehearsal/move 2.0.1` with `@rehearsal/move VERSION`.

### Bugs Found in rehearsal
**Ember@4.4 LTS**
- Graph creation for ember@4.4 does not work due to service decorate API changing. https://github.com/rehearsal-js/rehearsal-js/issues/998 ✅ 

**Ember@3.28 LTS**
- `app.js` is not compilable due to long comment. https://github.com/rehearsal-js/rehearsal-js/issues/999 ✅ 

### Considerations
Opted not to use `beforeEach` `beforeAll` hooks, in favor of calling a method to setup a project. This allows for using `test.each()` when writing multiple similar tests with the same assertion. 

Using a beforeEach Hook doesn't allow for passing arguments to the beforeEach hook like with a data provider. AFAIK.



### TODO
- [x] Needs assertion for Glint types being added.

