### PR TITLE
fix: fixes tests base on new api

### DIFF
--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -28,7 +28,7 @@ describe('smoke-test @rehearsal/cli no project', () => {
     expect(results.exitCode).toBe(0);
     expect(results.stdout).toContain('Usage: rehearsal [options] [command]');
     expect(results.stdout).toContain('migrate [options]');
-    expect(results.stdout).toContain('graph [options] [basePath]');
+    expect(results.stdout).toContain('graph [options] [srcDir]');
     expect(results.stdout).toContain('move|mv [options]');
     expect(results.stdout).toContain('help [command]');
   });
@@ -36,7 +36,7 @@ describe('smoke-test @rehearsal/cli no project', () => {
   test('graph command --help', () => {
     const results = run(['graph', '--help']);
     expect(results.exitCode).toBe(0);
-    expect(results.stdout).toContain('graph [options] [basePath]');
+    expect(results.stdout).toContain('graph [options] [srcDir]');
   });
 
   test('move command --help', () => {

--- a/test/graph.test.js
+++ b/test/graph.test.js
@@ -18,7 +18,7 @@ describe('validation-test: rehearsal graph', () => {
   test('graph --help', () => {
     const results = run(['graph', '--help']);
     expect(results.exitCode).toBe(0);
-    expect(results.stdout).toContain('graph [options] [basePath]');
+    expect(results.stdout).toContain('graph [options] [srcDir]');
   });
 
   test('graph', () => {

--- a/test/move.test.js
+++ b/test/move.test.js
@@ -5,8 +5,8 @@ describe('validation-test: rehearsal move', async () => {
   const variants = [
     { variant: 'simple', args: ['--help'] },
     //   { variant: 'simple', args: [] },
-    { variant: 'simple', args: ['--source', 'index.js'] },
-    { variant: 'workspace', args: ['--childPackage', 'packages/blorp'] }
+    { variant: 'simple', args: ['index.js'] },
+    { variant: 'workspace', args: ['packages/blorp', '--graph', '--deps', '--devDeps'] }
   ];
 
   test.each(variants)('$variant: move $args', async ({ variant, args }) => {


### PR DESCRIPTION
In https://github.com/rehearsal-js/rehearsal-js/pull/1025 we are making changes to the `graph` and `move` apis. This will update the tests to account for those changes.

That said this repo no longer needs to be external to rehearsal it self.
